### PR TITLE
Remove credentials_path requirement from testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,14 +78,7 @@ check_headers:
 # Integration tests
 .PHONY: test_integration
 test_integration:
-	source ${TEST_CONFIG_FILE_LOCATION}
-	bundle install
-	bundle exec kitchen create
-	bundle exec kitchen converge
-	bundle exec kitchen converge
-	@echo "Waiting ${GCE_INSTANCE_INIT_WAIT_TIME} seconds for load balancer to come online..."
-	bundle exec kitchen verify
-	bundle exec kitchen destroy
+	./test/ci_integration.sh
 
 .PHONY: generate_docs
 generate_docs:

--- a/README.md
+++ b/README.md
@@ -271,6 +271,49 @@ Run
 ```
 make generate_docs
 ```
+### Integration test
+
+Integration tests are run though [test-kitchen](https://github.com/test-kitchen/test-kitchen), [kitchen-terraform](https://github.com/newcontext-oss/kitchen-terraform), and [InSpec](https://github.com/inspec/inspec).
+
+`test-kitchen` instances are defined in [`.kitchen.yml`](./.kitchen.yml). The test-kitchen instances in `test/fixtures/` wrap identically-named examples in the `examples/` directory.
+
+#### Setup
+
+1. Configure the [test fixtures](#test-configuration)
+2. Download a Service Account key with the necessary permissions and put it in the module's root directory with the name `credentials.json`.
+3. Build the Docker container for testing:
+
+  ```
+  make docker_build_kitchen_terraform
+  ```
+4. Run the testing container in interactive mode:
+
+  ```
+  make docker_run
+  ```
+
+  The module root directory will be loaded into the Docker container at `/cft/workdir/`.
+5. Run kitchen-terraform to test the infrastructure:
+
+  1. `kitchen create` creates Terraform state and downloads modules, if applicable.
+  2. `kitchen converge` creates the underlying resources. Run `kitchen converge <INSTANCE_NAME>` to create resources for a specific test case.
+  3. `kitchen verify` tests the created infrastructure. Run `kitchen verify <INSTANCE_NAME>` to run a specific test case.
+  4. `kitchen destroy` tears down the underlying resources created by `kitchen converge`. Run `kitchen destroy <INSTANCE_NAME>` to tear down resources for a specific test case.
+
+Alternatively, you can simply run `make test_integration_docker` to run all the test steps non-interactively.
+
+#### Test configuration
+
+Each test-kitchen instance is configured with a `terraform.tfvars` file in the test fixture directory. For convenience, since all of the variables are project-specific, these files have been symlinked to `test/fixtures/shared/terraform.tfvars`.
+Similarly, each test fixture has a `variables.tf` to define these variables, and an `outputs.tf` to facilitate providing necessary information for `inspec` to locate and query against created resources.
+
+Each test-kitchen instance creates necessary fixtures to house resources.
+
+### Autogeneration of documentation from .tf files
+Run
+```
+make generate_docs
+```
 
 ### Linting
 The makefile in this project will lint or sometimes just format any shell,

--- a/examples/dns_forward_and_reverse/main.tf
+++ b/examples/dns_forward_and_reverse/main.tf
@@ -15,9 +15,8 @@
  */
 
 provider "google" {
-  credentials = "${file(var.credentials_path)}"
-  project     = "${var.project_id}"
-  region      = "${var.region}"
+  project = "${var.project_id}"
+  region  = "${var.region}"
 }
 
 module "address" {

--- a/examples/dns_forward_and_reverse/terraform.tfvars.sample
+++ b/examples/dns_forward_and_reverse/terraform.tfvars.sample
@@ -2,10 +2,6 @@
 region           = "us-west1"
 project_id       = "my-project-name"
 
-# Path to the credentials file of an account with sufficient access to
-# create resources via Terraform
-credentials_path = "/path/to/credentials.json"
-
 # The domain name to be used for the example
 dns_domain       = "example.org"
 

--- a/examples/dns_forward_and_reverse/variables.tf
+++ b/examples/dns_forward_and_reverse/variables.tf
@@ -18,10 +18,6 @@ variable "project_id" {
   description = "The project ID to deploy to"
 }
 
-variable "credentials_path" {
-  description = "The path to a Google Cloud Service Account credentials file"
-}
-
 variable "dns_domain" {
   description = "The name of the domain to be registered with Cloud DNS"
 }

--- a/examples/dns_forward_example/terraform.tfvars.sample
+++ b/examples/dns_forward_example/terraform.tfvars.sample
@@ -2,10 +2,6 @@
 region           = "us-west1"
 project_id       = "my-project-name"
 
-# Path to the credentials file of an account with sufficient access to
-# create resources via Terraform
-credentials_path = "/path/to/credentials.json"
-
 # The domain name to be used for the example
 dns_domain       = "example.org"
 

--- a/examples/dns_forward_example/variables.tf
+++ b/examples/dns_forward_example/variables.tf
@@ -18,10 +18,6 @@ variable "project_id" {
   description = "The project ID to deploy to"
 }
 
-variable "credentials_path" {
-  description = "The path to a Google Cloud Service Account credentials file"
-}
-
 variable "dns_domain" {
   description = "The name of the domain to be registered with Cloud DNS"
 }

--- a/examples/ip_address_only/main.tf
+++ b/examples/ip_address_only/main.tf
@@ -15,9 +15,8 @@
  */
 
 provider "google" {
-  credentials = "${file(var.credentials_path)}"
-  project     = "${var.project_id}"
-  region      = "${var.region}"
+  project = "${var.project_id}"
+  region  = "${var.region}"
 }
 
 module "address" {

--- a/examples/ip_address_only/terraform.tfvars.sample
+++ b/examples/ip_address_only/terraform.tfvars.sample
@@ -2,10 +2,6 @@
 region           = "us-west1"
 project_id       = "my-project-name"
 
-# Path to the credentials file of an account with sufficient access to
-# create resources via Terraform
-credentials_path = "/path/to/credentials.json"
-
 # Subnetwork where the IP Address will be reserved
 subnetwork       = ""
 

--- a/examples/ip_address_only/variables.tf
+++ b/examples/ip_address_only/variables.tf
@@ -18,10 +18,6 @@ variable "project_id" {
   description = "The project ID to deploy to"
 }
 
-variable "credentials_path" {
-  description = "The path to a Google Cloud Service Account credentials file"
-}
-
 variable "region" {
   description = "The region to deploy to"
 }

--- a/examples/ip_address_with_specific_ip/main.tf
+++ b/examples/ip_address_with_specific_ip/main.tf
@@ -15,9 +15,8 @@
  */
 
 provider "google" {
-  credentials = "${file(var.credentials_path)}"
-  project     = "${var.project_id}"
-  region      = "${var.region}"
+  project = "${var.project_id}"
+  region  = "${var.region}"
 }
 
 module "address" {

--- a/examples/ip_address_with_specific_ip/terraform.tfvars.sample
+++ b/examples/ip_address_with_specific_ip/terraform.tfvars.sample
@@ -2,10 +2,6 @@
 region           = "us-west1"
 project_id       = "my-project-name"
 
-# Path to the credentials file of an account with sufficient access to
-# create resources via Terraform
-credentials_path = "/path/to/credentials.json"
-
 # Subnetwork where the IP Address will be reserved
 subnetwork       = ""
 

--- a/examples/ip_address_with_specific_ip/variables.tf
+++ b/examples/ip_address_with_specific_ip/variables.tf
@@ -18,10 +18,6 @@ variable "project_id" {
   description = "The project ID to deploy to"
 }
 
-variable "credentials_path" {
-  description = "The path to a Google Cloud Service Account credentials file"
-}
-
 variable "region" {
   description = "The region to deploy to"
 }

--- a/test/fixtures/all_examples/test_outputs.tfshared
+++ b/test/fixtures/all_examples/test_outputs.tfshared
@@ -19,11 +19,6 @@ output "region" {
   value       = "${var.region}"
 }
 
-output "credentials_path" {
-  description = "Path to credentials file being used"
-  value       = "${var.credentials_path}"
-}
-
 output "project_id" {
   description = "ID of the project being used"
   value       = "${var.project_id}"

--- a/test/fixtures/dns_forward_and_reverse/main.tf
+++ b/test/fixtures/dns_forward_and_reverse/main.tf
@@ -18,7 +18,6 @@ module "example" {
   source           = "../../../examples/dns_forward_and_reverse"
   project_id       = "${var.project_id}"
   region           = "${var.region}"
-  credentials_path = "${local.credentials_path}"
   subnetwork       = "${google_compute_subnetwork.main.name}"
   dns_project      = "${var.project_id}"
   dns_domain       = "${local.domain}"

--- a/test/fixtures/dns_forward_and_reverse/network.tf
+++ b/test/fixtures/dns_forward_and_reverse/network.tf
@@ -15,11 +15,10 @@
  */
 
 locals {
-  credentials_path = "${path.module}/${var.credentials_path}"
-  randomized_name  = "cft-address-test-${random_string.suffix.result}"
-  domain           = "justfortesting.local"
-  forward_zone     = "forward-cft-address-test"
-  reverse_zone     = "reverse-cft-address-test"
+  randomized_name = "cft-address-test-${random_string.suffix.result}"
+  domain          = "justfortesting.local"
+  forward_zone    = "forward-cft-address-test"
+  reverse_zone    = "reverse-cft-address-test"
 }
 
 resource "random_string" "suffix" {
@@ -29,8 +28,7 @@ resource "random_string" "suffix" {
 }
 
 provider "google" {
-  credentials = "${file(local.credentials_path)}"
-  project     = "${var.project_id}"
+  project = "${var.project_id}"
 }
 
 resource "google_compute_network" "main" {

--- a/test/fixtures/dns_forward_example/main.tf
+++ b/test/fixtures/dns_forward_example/main.tf
@@ -18,7 +18,6 @@ module "example" {
   source           = "../../../examples/dns_forward_example"
   project_id       = "${var.project_id}"
   region           = "${var.region}"
-  credentials_path = "${local.credentials_path}"
   subnetwork       = "${google_compute_subnetwork.main.name}"
   dns_project      = "${var.project_id}"
   dns_domain       = "${local.domain}"

--- a/test/fixtures/dns_forward_example/network.tf
+++ b/test/fixtures/dns_forward_example/network.tf
@@ -15,10 +15,9 @@
  */
 
 locals {
-  credentials_path = "${path.module}/${var.credentials_path}"
-  randomized_name  = "cft-address-test-${random_string.suffix.result}"
-  domain           = "justfortesting.local"
-  forward_zone     = "forward-example-only"
+  randomized_name = "cft-address-test-${random_string.suffix.result}"
+  domain          = "justfortesting.local"
+  forward_zone    = "forward-example-only"
 }
 
 resource "random_string" "suffix" {
@@ -28,8 +27,7 @@ resource "random_string" "suffix" {
 }
 
 provider "google" {
-  credentials = "${file(local.credentials_path)}"
-  project     = "${var.project_id}"
+  project = "${var.project_id}"
 }
 
 resource "google_compute_network" "main" {

--- a/test/fixtures/ip_address_only/main.tf
+++ b/test/fixtures/ip_address_only/main.tf
@@ -15,10 +15,9 @@
  */
 
 module "example" {
-  source           = "../../../examples/ip_address_only"
-  project_id       = "${var.project_id}"
-  region           = "${var.region}"
-  credentials_path = "${local.credentials_path}"
-  subnetwork       = "${google_compute_subnetwork.main.name}"
-  names            = ["dynamically-assigned-ip-001"]
+  source     = "../../../examples/ip_address_only"
+  project_id = "${var.project_id}"
+  region     = "${var.region}"
+  subnetwork = "${google_compute_subnetwork.main.name}"
+  names      = ["dynamically-assigned-ip-001"]
 }

--- a/test/fixtures/ip_address_with_specific_ip/main.tf
+++ b/test/fixtures/ip_address_with_specific_ip/main.tf
@@ -15,11 +15,10 @@
  */
 
 module "example" {
-  source           = "../../../examples/ip_address_with_specific_ip"
-  project_id       = "${var.project_id}"
-  region           = "${var.region}"
-  credentials_path = "${local.credentials_path}"
-  subnetwork       = "${google_compute_subnetwork.main.name}"
-  addresses        = ["10.13.0.100"]
-  names            = ["statically-reserved-ip-001"]
+  source     = "../../../examples/ip_address_with_specific_ip"
+  project_id = "${var.project_id}"
+  region     = "${var.region}"
+  subnetwork = "${google_compute_subnetwork.main.name}"
+  addresses  = ["10.13.0.100"]
+  names      = ["statically-reserved-ip-001"]
 }

--- a/test/fixtures/shared/no_dns/network.tfshared
+++ b/test/fixtures/shared/no_dns/network.tfshared
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-locals {
-  credentials_path = "${path.module}/${var.credentials_path}"
-}
-
 resource "random_string" "suffix" {
   length  = 4
   special = false
@@ -25,8 +21,7 @@ resource "random_string" "suffix" {
 }
 
 provider "google" {
-  credentials = "${file(local.credentials_path)}"
-  project     = "${var.project_id}"
+  project = "${var.project_id}"
 }
 
 resource "google_compute_network" "main" {

--- a/test/fixtures/shared/shared_outputs.tfshared
+++ b/test/fixtures/shared/shared_outputs.tfshared
@@ -18,10 +18,6 @@ output "project_id" {
   value = "${var.project_id}"
 }
 
-output "credentials_path" {
-  value = "${local.credentials_path}"
-}
-
 output "region" {
   value = "${module.example.region}"
 }

--- a/test/fixtures/shared/terraform.tfvars.sample
+++ b/test/fixtures/shared/terraform.tfvars.sample
@@ -1,3 +1,2 @@
-credentials_path = "../../../credentials.json"
 region           = "us-west1"
 project_id       = ""

--- a/test/fixtures/shared/variables.tfshared
+++ b/test/fixtures/shared/variables.tfshared
@@ -18,10 +18,6 @@ variable "project_id" {
   description = "The project ID to deploy to"
 }
 
-variable "credentials_path" {
-  description = "The path tory to the GCP credentials file that will run Terraform tests"
-}
-
 variable "region" {
   description = "The region to deploy to"
 }

--- a/test/fixtures/simulated_ci_environment/README.md
+++ b/test/fixtures/simulated_ci_environment/README.md
@@ -1,0 +1,53 @@
+# Integration Testing
+
+Use this directory to create resources reflecting the same resource fixtures
+created for use by the CI environment CI integration test pipelines.  The intent
+of these resources is to run the integration tests locally as closely as
+possible to how they will run in the CI system.
+
+Once created, store the service account key content into the
+`GOOGLE_CREDENTIALS` environment variable.  This reflects the same behavior as
+used in CI.
+
+For example:
+
+```bash
+terraform init
+terraform apply
+terraform output service_account_private_key > ~/.credentials/address-sa.json
+```
+
+Then, configure the environment (suggest using direnv) like so:
+
+```bash
+export GOOGLE_CREDENTIALS_PATH="${HOME}/.credentials/address-sa.json"
+export GOOGLE_CREDENTIALS="${HOME}/.credentials/address-sa.json"
+export TF_VAR_project_id="address-module"
+export TF_VAR_region="us-west1"
+```
+
+With these variables set, change to the root of the module and execute the `make test_integration` task.
+This make target is the same that is executed by this module's CI pipeline during integration testing.
+
+For example:
+
+[^]: (autogen_docs_start)
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| billing_account | The billing account id associated with the project, e.g. XXXXXX-YYYYYY-ZZZZZZ | string | - | yes |
+| folder_id | The numeric folder id to create resources | string | - | yes |
+| organization_id | The numeric organization id | string | - | yes |
+| project_id | The project_id to deploy the example instance into.  (e.g. "simple-sample-project-1234") | string | - | yes |
+| region | The region to deploy to | string | - | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| service_account_private_key | The SA KEY JSON content.  Store in GOOGLE_CREDENTIALS. |
+
+[^]: (autogen_docs_end)

--- a/test/fixtures/simulated_ci_environment/main.tf
+++ b/test/fixtures/simulated_ci_environment/main.tf
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+provider "google" {
+  project = "${local.project_id}"
+  region  = "${var.region}"
+}
+
+locals {
+  project_id = "address-module"
+
+  required_service_account_project_roles = [
+    "roles/compute.networkAdmin",
+    "roles/dns.admin",
+    "roles/iam.serviceAccountUser",
+  ]
+
+  services = [
+    "oslogin.googleapis.com",
+    "cloudresourcemanager.googleapis.com",
+    "compute.googleapis.com",
+    "dns.googleapis.com",
+  ]
+}
+
+resource "google_project" "address" {
+  name            = "${local.project_id}"
+  project_id      = "${local.project_id}"
+  folder_id       = "${var.folder_id}"
+  billing_account = "${var.billing_account}"
+}
+
+resource "google_project_service" "address" {
+  count              = "${length(local.services)}"
+  project            = "${google_project.address.id}"
+  service            = "${element(local.services, count.index)}"
+  disable_on_destroy = "true"
+}
+
+resource "google_service_account" "address" {
+  project      = "${google_project.address.id}"
+  account_id   = "ci-address"
+  display_name = "ci-address"
+}
+
+resource "google_project_iam_member" "address" {
+  count   = "${length(local.required_service_account_project_roles)}"
+  project = "${google_project.address.id}"
+  role    = "${element(local.required_service_account_project_roles, count.index)}"
+  member  = "serviceAccount:${google_service_account.address.email}"
+}
+
+resource "google_service_account_key" "address" {
+  service_account_id = "${google_service_account.address.id}"
+}

--- a/test/fixtures/simulated_ci_environment/outputs.tf
+++ b/test/fixtures/simulated_ci_environment/outputs.tf
@@ -13,19 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-provider "google" {
-  project = "${var.project_id}"
-  region  = "${var.region}"
-}
-
-module "address" {
-  source           = "../../"
-  subnetwork       = "${var.subnetwork}"
-  enable_cloud_dns = "true"
-  dns_domain       = "${var.dns_domain}"
-  dns_managed_zone = "${var.dns_managed_zone}"
-  dns_project      = "${var.dns_project}"
-  names            = "${var.names}"
-  dns_short_names  = "${var.dns_short_names}"
+output "service_account_private_key" {
+  description = "The SA KEY JSON content.  Store in GOOGLE_CREDENTIALS."
+  value       = "${base64decode(google_service_account_key.address.private_key)}"
 }

--- a/test/fixtures/simulated_ci_environment/terraform.tfvars.sample
+++ b/test/fixtures/simulated_ci_environment/terraform.tfvars.sample
@@ -1,0 +1,4 @@
+folder_id       = ""
+organization_id = ""
+billing_account = ""
+region          = ""

--- a/test/fixtures/simulated_ci_environment/variables.tf
+++ b/test/fixtures/simulated_ci_environment/variables.tf
@@ -14,18 +14,21 @@
  * limitations under the License.
  */
 
-provider "google" {
-  project = "${var.project_id}"
-  region  = "${var.region}"
+variable "region" {
+  description = "The region to deploy to"
 }
 
-module "address" {
-  source           = "../../"
-  subnetwork       = "${var.subnetwork}"
-  enable_cloud_dns = "true"
-  dns_domain       = "${var.dns_domain}"
-  dns_managed_zone = "${var.dns_managed_zone}"
-  dns_project      = "${var.dns_project}"
-  names            = "${var.names}"
-  dns_short_names  = "${var.dns_short_names}"
+variable "organization_id" {
+  description = "The numeric organization id"
+  type        = "string"
+}
+
+variable "folder_id" {
+  description = "The numeric folder id to create resources"
+  type        = "string"
+}
+
+variable "billing_account" {
+  description = "The billing account id associated with the project, e.g. XXXXXX-YYYYYY-ZZZZZZ"
+  type        = "string"
 }

--- a/test/integration/dns_forward_and_reverse/controls/gcloud.rb
+++ b/test/integration/dns_forward_and_reverse/controls/gcloud.rb
@@ -13,17 +13,12 @@
 # limitations under the License.
 
 project_id        = attribute('project_id')
-credentials_path  = attribute('credentials_path')
 addresses         = attribute('addresses')
 dns_fqdns         = attribute('dns_fqdns')
 reverse_dns_fqdns = attribute('reverse_dns_fqdns')
 names             = attribute('names')
 forward_zone      = attribute('forward_zone')
 reverse_zone      = attribute('reverse_zone')
-
-ENV['CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE'] = File.absolute_path(
-  credentials_path,
-  File.join(__dir__, "../../../../examples/dns_forward_and_reverse"))
 
 control "dns-forward-and-reverse" do
   title "Address module - DNS example with forward and reverse lookup registration"

--- a/test/integration/dns_forward_and_reverse/inspec.yml
+++ b/test/integration/dns_forward_and_reverse/inspec.yml
@@ -22,10 +22,6 @@ attributes:
     required: true
     type: string
 
-  - name: credentials_path
-    required: true
-    type: string
-
   - name: addresses
     required: true
     type: array

--- a/test/integration/dns_forward_example/controls/gcloud.rb
+++ b/test/integration/dns_forward_example/controls/gcloud.rb
@@ -13,13 +13,10 @@
 # limitations under the License.
 
 project_id       = attribute('project_id')
-credentials_path = attribute('credentials_path')
 addresses        = attribute('addresses')
 dns_fqdns        = attribute('dns_fqdns')
 names            = attribute('names')
 forward_zone     = attribute('forward_zone')
-
-ENV['CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE'] = credentials_path
 
 control "dns-forward-example" do
   title "Address module - DNS example with forward lookup registration"

--- a/test/integration/dns_forward_example/inspec.yml
+++ b/test/integration/dns_forward_example/inspec.yml
@@ -18,10 +18,6 @@ attributes:
     required: true
     type: string
 
-  - name: credentials_path
-    required: true
-    type: string
-
   - name: addresses
     required: true
     type: array

--- a/test/integration/ip_address_only/controls/gcloud.rb
+++ b/test/integration/ip_address_only/controls/gcloud.rb
@@ -13,11 +13,8 @@
 # limitations under the License.
 
 project_id       = attribute('project_id')
-credentials_path = attribute('credentials_path')
 names            = attribute('names')
 addresses        = attribute('addresses')
-
-ENV['CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE'] = credentials_path
 
 control "ip-address-only" do
   title "Address module - dynamic IP address configuration"

--- a/test/integration/ip_address_only/inspec.yml
+++ b/test/integration/ip_address_only/inspec.yml
@@ -18,10 +18,6 @@ attributes:
     required: true
     type: string
 
-  - name: credentials_path
-    required: true
-    type: string
-
   - name: names
     required: true
     type: array

--- a/test/integration/ip_address_with_specific_ip/controls/gcloud.rb
+++ b/test/integration/ip_address_with_specific_ip/controls/gcloud.rb
@@ -13,11 +13,8 @@
 # limitations under the License.
 
 project_id       = attribute('project_id')
-credentials_path = attribute('credentials_path')
 addresses        = attribute('addresses')
 names            = attribute('names')
-
-ENV['CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE'] = credentials_path
 
 control "ip-address-with-specific-ip" do
   title "Address module IP address only configuration"

--- a/test/integration/ip_address_with_specific_ip/inspec.yml
+++ b/test/integration/ip_address_with_specific_ip/inspec.yml
@@ -18,10 +18,6 @@ attributes:
     required: true
     type: string
 
-  - name: credentials_path
-    required: true
-    type: string
-
   - name: names
     required: true
     type: array


### PR DESCRIPTION
This commit removes the `credentials_path` input variable from all test
fixtures and examples in favor of relying upon the environment variables
that the Google Cloud SDK respects. This is already happening when the
`make test_integration_docker` target is executed as the
`credentials.json` file is mapped to
`CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE` by `test/fixtures/config.sh`.

Instead, the `test/ci_integration.sh` script was updated to accept the
environment variable containing the service account JSON body coming
from Concourse (`$SERVICE_ACCOUNT_JSON`), and the `make
test_integration` target was updated to reference the
`test/ci_integration.sh` script. In addition, the
`test/fixtures/simulated_ci_environment` test fixture was added to allow
the module consumer to replicate the test dependencies that are used in
CI, and when combined with the `make test_integration` target will allow
that same module consumer to replicate the CI pipeline execution on their
machine.

Finally, the README has been updated with changes from the module
template to document the integration testing process using the Docker
container.