### PR TITLE
Add project ID as input

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,34 +173,34 @@ Terraform may change this fact, but this is the current limitation.
 
 [^]: (autogen_docs_start)
 
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| address_type | The type of address to reserve, either "INTERNAL" or "EXTERNAL". If unspecified, defaults to "INTERNAL". | string | `INTERNAL` | no |
+| address\_type | The type of address to reserve, either "INTERNAL" or "EXTERNAL". If unspecified, defaults to "INTERNAL". | string | `"INTERNAL"` | no |
 | addresses | A list of IP addresses to create.  GCP will reserve unreserved addresses if given the value "".  If multiple names are given the default value is sufficient to have multiple addresses automatically picked for each name. | list | `<list>` | no |
-| dns_domain | The domain to append to DNS short names when registering in Cloud DNS. | string | `` | no |
-| dns_managed_zone | The name of the managed zone to create records within.  This managed zone must exist in the host project. | string | `` | no |
-| dns_project | The project where DNS A records will be configured. | string | `` | no |
-| dns_record_type | The type of records to create in the managed zone.  (e.g. "A") | string | `A` | no |
-| dns_reverse_zone | The name of the managed zone to create PTR records within.  This managed zone must exist in the host project. | string | `` | no |
-| dns_short_names | A list of DNS short names to register within Cloud DNS.  Names corresponding to addresses must align by their list index position in the two input variables, `names` and `dns_short_names`.  If an empty list, no domain names are registered.  Multiple names may be registered to the same address by passing a single element list to names and multiple elements to dns_short_names.  (e.g. ["gusw1-dev-fooapp-fe-0001-a-001"]) | list | `<list>` | no |
-| dns_ttl | The DNS TTL in seconds for records created in Cloud DNS.  The default value should be used unless the application demands special handling. | string | `300` | no |
-| enable_cloud_dns | If a value is set, register records in Cloud DNS. | string | `` | no |
-| enable_reverse_dns | If a value is set, register reverse DNS PTR records in Cloud DNS in the managed zone specified by dns_reverse_zone | string | `` | no |
-| global | The scope in which the address should live. If set to true, the IP address will be globally scoped. Defaults to false, i.e. regionally scoped. When set to true, do not provide a subnetwork. | string | `false` | no |
+| dns\_domain | The domain to append to DNS short names when registering in Cloud DNS. | string | `""` | no |
+| dns\_managed\_zone | The name of the managed zone to create records within.  This managed zone must exist in the host project. | string | `""` | no |
+| dns\_project | The project where DNS A records will be configured. | string | `""` | no |
+| dns\_record\_type | The type of records to create in the managed zone.  (e.g. "A") | string | `"A"` | no |
+| dns\_reverse\_zone | The name of the managed zone to create PTR records within.  This managed zone must exist in the host project. | string | `""` | no |
+| dns\_short\_names | A list of DNS short names to register within Cloud DNS.  Names corresponding to addresses must align by their list index position in the two input variables, `names` and `dns_short_names`.  If an empty list, no domain names are registered.  Multiple names may be registered to the same address by passing a single element list to names and multiple elements to dns_short_names.  (e.g. ["gusw1-dev-fooapp-fe-0001-a-001"]) | list | `<list>` | no |
+| dns\_ttl | The DNS TTL in seconds for records created in Cloud DNS.  The default value should be used unless the application demands special handling. | string | `"300"` | no |
+| enable\_cloud\_dns | If a value is set, register records in Cloud DNS. | string | `""` | no |
+| enable\_reverse\_dns | If a value is set, register reverse DNS PTR records in Cloud DNS in the managed zone specified by dns_reverse_zone | string | `""` | no |
+| global | The scope in which the address should live. If set to true, the IP address will be globally scoped. Defaults to false, i.e. regionally scoped. When set to true, do not provide a subnetwork. | string | `"false"` | no |
 | names | A list of IP address resource names to create.  This is the GCP resource name and not the associated hostname of the IP address.  Existing resource names may be found with `gcloud compute addresses list` (e.g. ["gusw1-dev-fooapp-fe-0001-a-001-ip"]) | list | `<list>` | no |
-| subnetwork | The subnet containing the address.  For EXTERNAL addresses use the empty string, "".  (e.g. "projects/<project-name>/regions/<region-name>/subnetworks/<subnetwork-name>") | string | `` | no |
+| project\_id | The project ID to create the address in | string | n/a | yes |
+| subnetwork | The subnet containing the address.  For EXTERNAL addresses use the empty string, "".  (e.g. "projects/<project-name>/regions/<region-name>/subnetworks/<subnetwork-name>") | string | `""` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
 | addresses | List of address values managed by this module (e.g. ["1.2.3.4"]) |
-| dns_fqdns | List of DNS fully qualified domain names registered in Cloud DNS.  (e.g. ["gusw1-dev-fooapp-fe-0001-a-001.example.com", "gusw1-dev-fooapp-fe-0001-a-0002.example.com"]) |
+| dns\_fqdns | List of DNS fully qualified domain names registered in Cloud DNS.  (e.g. ["gusw1-dev-fooapp-fe-0001-a-001.example.com", "gusw1-dev-fooapp-fe-0001-a-0002.example.com"]) |
 | names | List of address resource names managed by this module (e.g. ["gusw1-dev-fooapp-fe-0001-a-0001-ip"]) |
-| reverse_dns_fqdns | List of reverse DNS PTR records registered in Cloud DNS.  (e.g. ["1.2.11.10.in-addr.arpa", "2.2.11.10.in-addr.arpa"]) |
+| reverse\_dns\_fqdns | List of reverse DNS PTR records registered in Cloud DNS.  (e.g. ["1.2.11.10.in-addr.arpa", "2.2.11.10.in-addr.arpa"]) |
 
 [^]: (autogen_docs_end)
 

--- a/examples/dns_forward_and_reverse/README.md
+++ b/examples/dns_forward_and_reverse/README.md
@@ -6,35 +6,32 @@ both forward and reverse DNS lookup zones.
 
 [^]: (autogen_docs_start)
 
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| credentials_path | The path to a Google Cloud Service Account credentials file | string | - | yes |
-| dns_domain | The name of the domain to be registered with Cloud DNS | string | - | yes |
-| dns_managed_zone | The name of the managed zone to create records within.  This managed zone must exist in the host project. | string | - | yes |
-| dns_project | The project where DNS A records will be configured. | string | - | yes |
-| dns_reverse_zone | The name of the managed zone to create PTR records within.  This managed zone must exist in the host project. | string | - | yes |
-| dns_short_names | A list of DNS short names to register within Cloud DNS.  Names corresponding to addresses must align by their list index position in the two input variables, `names` and `dns_short_names`.  If an empty list, no domain names are registered.  Multiple names may be registered to the same address by passing a single element list to names and multiple elements to dns_short_names.  (e.g. ["gusw1-dev-fooapp-fe-0001-a-001"]) | list | - | yes |
-| names | A list of IP address resource names to create.  This is the GCP resource name and not the associated hostname of the IP address.  Existing resource names may be found with `gcloud compute addresses list` (e.g. ["gusw1-dev-fooapp-fe-0001-a-001-ip"]) | list | - | yes |
-| project_id | The project ID to deploy to | string | - | yes |
-| region | The region to deploy to | string | - | yes |
-| subnetwork | The subnet containing the address.  For EXTERNAL addresses use the empty string, "".  (e.g. "projects/<project-name>/regions/<region-name>/subnetworks/<subnetwork-name>") | string | - | yes |
+| dns\_domain | The name of the domain to be registered with Cloud DNS | string | n/a | yes |
+| dns\_managed\_zone | The name of the managed zone to create records within.  This managed zone must exist in the host project. | string | n/a | yes |
+| dns\_project | The project where DNS A records will be configured. | string | n/a | yes |
+| dns\_reverse\_zone | The name of the managed zone to create PTR records within.  This managed zone must exist in the host project. | string | n/a | yes |
+| dns\_short\_names | A list of DNS short names to register within Cloud DNS.  Names corresponding to addresses must align by their list index position in the two input variables, `names` and `dns_short_names`.  If an empty list, no domain names are registered.  Multiple names may be registered to the same address by passing a single element list to names and multiple elements to dns_short_names.  (e.g. ["gusw1-dev-fooapp-fe-0001-a-001"]) | list | n/a | yes |
+| names | A list of IP address resource names to create.  This is the GCP resource name and not the associated hostname of the IP address.  Existing resource names may be found with `gcloud compute addresses list` (e.g. ["gusw1-dev-fooapp-fe-0001-a-001-ip"]) | list | n/a | yes |
+| project\_id | The project ID to deploy to | string | n/a | yes |
+| region | The region to deploy to | string | n/a | yes |
+| subnetwork | The subnet containing the address.  For EXTERNAL addresses use the empty string, "".  (e.g. "projects/<project-name>/regions/<region-name>/subnetworks/<subnetwork-name>") | string | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
 | addresses | List of address values managed by this module (e.g. ["1.2.3.4"]) |
-| credentials_path | Path to credentials file being used |
-| dns_fqdns | List of DNS fully qualified domain names registered in Cloud DNS.  (e.g. ["gusw1-dev-fooapp-fe-0001-a-001.example.com", "gusw1-dev-fooapp-fe-0001-a-0002.example.com"]) |
-| forward_zone | The GCP name of the forward lookup DNS zone being used |
+| dns\_fqdns | List of DNS fully qualified domain names registered in Cloud DNS.  (e.g. ["gusw1-dev-fooapp-fe-0001-a-001.example.com", "gusw1-dev-fooapp-fe-0001-a-0002.example.com"]) |
+| forward\_zone | The GCP name of the forward lookup DNS zone being used |
 | names | List of address resource names managed by this module (e.g. ["gusw1-dev-fooapp-fe-0001-a-0001-ip"]) |
-| project_id | ID of the project being used |
+| project\_id | ID of the project being used |
 | region | Region being used |
-| reverse_dns_fqdns | List of reverse DNS PTR records registered in Cloud DNS. |
-| reverse_zone | The GCP name of the reverse lookup DNS zone being used |
+| reverse\_dns\_fqdns | List of reverse DNS PTR records registered in Cloud DNS. |
+| reverse\_zone | The GCP name of the reverse lookup DNS zone being used |
 
 [^]: (autogen_docs_end)
 

--- a/examples/dns_forward_and_reverse/main.tf
+++ b/examples/dns_forward_and_reverse/main.tf
@@ -15,12 +15,12 @@
  */
 
 provider "google" {
-  project = "${var.project_id}"
-  region  = "${var.region}"
+  region = "${var.region}"
 }
 
 module "address" {
   source           = "../../"
+  project_id       = "${var.project_id}"
   subnetwork       = "${var.subnetwork}"
   enable_cloud_dns = "true"
   dns_domain       = "${var.dns_domain}"

--- a/examples/dns_forward_example/README.md
+++ b/examples/dns_forward_example/README.md
@@ -7,31 +7,28 @@ Cloud DNS.
 
 [^]: (autogen_docs_start)
 
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| credentials_path | The path to a Google Cloud Service Account credentials file | string | - | yes |
-| dns_domain | The name of the domain to be registered with Cloud DNS | string | - | yes |
-| dns_managed_zone | The name of the managed zone to create records within.  This managed zone must exist in the host project. | string | - | yes |
-| dns_project | The project where DNS A records will be configured. | string | - | yes |
-| dns_short_names | A list of DNS short names to register within Cloud DNS.  Names corresponding to addresses must align by their list index position in the two input variables, `names` and `dns_short_names`.  If an empty list, no domain names are registered.  Multiple names may be registered to the same address by passing a single element list to names and multiple elements to dns_short_names.  (e.g. ["gusw1-dev-fooapp-fe-0001-a-001"]) | list | - | yes |
-| names | A list of IP address resource names to create.  This is the GCP resource name and not the associated hostname of the IP address.  Existing resource names may be found with `gcloud compute addresses list` (e.g. ["gusw1-dev-fooapp-fe-0001-a-001-ip"]) | list | - | yes |
-| project_id | The project ID to deploy to | string | - | yes |
-| region | The region to deploy to | string | - | yes |
-| subnetwork | The subnet containing the address.  For EXTERNAL addresses use the empty string, "".  (e.g. "projects/<project-name>/regions/<region-name>/subnetworks/<subnetwork-name>") | string | - | yes |
+| dns\_domain | The name of the domain to be registered with Cloud DNS | string | n/a | yes |
+| dns\_managed\_zone | The name of the managed zone to create records within.  This managed zone must exist in the host project. | string | n/a | yes |
+| dns\_project | The project where DNS A records will be configured. | string | n/a | yes |
+| dns\_short\_names | A list of DNS short names to register within Cloud DNS.  Names corresponding to addresses must align by their list index position in the two input variables, `names` and `dns_short_names`.  If an empty list, no domain names are registered.  Multiple names may be registered to the same address by passing a single element list to names and multiple elements to dns_short_names.  (e.g. ["gusw1-dev-fooapp-fe-0001-a-001"]) | list | n/a | yes |
+| names | A list of IP address resource names to create.  This is the GCP resource name and not the associated hostname of the IP address.  Existing resource names may be found with `gcloud compute addresses list` (e.g. ["gusw1-dev-fooapp-fe-0001-a-001-ip"]) | list | n/a | yes |
+| project\_id | The project ID to deploy to | string | n/a | yes |
+| region | The region to deploy to | string | n/a | yes |
+| subnetwork | The subnet containing the address.  For EXTERNAL addresses use the empty string, "".  (e.g. "projects/<project-name>/regions/<region-name>/subnetworks/<subnetwork-name>") | string | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
 | addresses | List of address values managed by this module (e.g. ["1.2.3.4"]) |
-| credentials_path | Path to credentials file being used |
-| dns_fqdns | List of DNS fully qualified domain names registered in Cloud DNS.  (e.g. ["gusw1-dev-fooapp-fe-0001-a-001.example.com", "gusw1-dev-fooapp-fe-0001-a-0002.example.com"]) |
-| forward_zone | The GCP name of the forward lookup DNS zone being used |
+| dns\_fqdns | List of DNS fully qualified domain names registered in Cloud DNS.  (e.g. ["gusw1-dev-fooapp-fe-0001-a-001.example.com", "gusw1-dev-fooapp-fe-0001-a-0002.example.com"]) |
+| forward\_zone | The GCP name of the forward lookup DNS zone being used |
 | names | List of address resource names managed by this module (e.g. ["gusw1-dev-fooapp-fe-0001-a-0001-ip"]) |
-| project_id | ID of the project being used |
+| project\_id | ID of the project being used |
 | region | Region being used |
 
 [^]: (autogen_docs_end)

--- a/examples/dns_forward_example/main.tf
+++ b/examples/dns_forward_example/main.tf
@@ -15,12 +15,12 @@
  */
 
 provider "google" {
-  project = "${var.project_id}"
-  region  = "${var.region}"
+  region = "${var.region}"
 }
 
 module "address" {
   source           = "../../"
+  project_id       = "${var.project_id}"
   subnetwork       = "${var.subnetwork}"
   enable_cloud_dns = "true"
   dns_domain       = "${var.dns_domain}"

--- a/examples/ip_address_only/README.md
+++ b/examples/ip_address_only/README.md
@@ -6,25 +6,22 @@ itself as well as the resource name that corresponds.
 
 [^]: (autogen_docs_start)
 
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| credentials_path | The path to a Google Cloud Service Account credentials file | string | - | yes |
-| names | A list of IP address resource names to create.  This is the GCP resource name and not the associated hostname of the IP address.  Existing resource names may be found with `gcloud compute addresses list` (e.g. ["gusw1-dev-fooapp-fe-0001-a-001-ip"]) | list | - | yes |
-| project_id | The project ID to deploy to | string | - | yes |
-| region | The region to deploy to | string | - | yes |
-| subnetwork | The subnetwork on which the IP address will be reserved | string | - | yes |
+| names | A list of IP address resource names to create.  This is the GCP resource name and not the associated hostname of the IP address.  Existing resource names may be found with `gcloud compute addresses list` (e.g. ["gusw1-dev-fooapp-fe-0001-a-001-ip"]) | list | n/a | yes |
+| project\_id | The project ID to deploy to | string | n/a | yes |
+| region | The region to deploy to | string | n/a | yes |
+| subnetwork | The subnetwork on which the IP address will be reserved | string | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
 | addresses | List of address values managed by this module (e.g. ["1.2.3.4"]) |
-| credentials_path | Path to credentials file being used |
 | names | List of address resource names managed by this module (e.g. ["gusw1-dev-fooapp-fe-0001-a-0001-ip"]) |
-| project_id | ID of the project being used |
+| project\_id | ID of the project being used |
 | region | Region being used |
 
 [^]: (autogen_docs_end)

--- a/examples/ip_address_only/main.tf
+++ b/examples/ip_address_only/main.tf
@@ -15,12 +15,12 @@
  */
 
 provider "google" {
-  project = "${var.project_id}"
-  region  = "${var.region}"
+  region = "${var.region}"
 }
 
 module "address" {
   source     = "../../"
+  project_id = "${var.project_id}"
   subnetwork = "${var.subnetwork}"
   names      = "${var.names}"
 }

--- a/examples/ip_address_with_specific_ip/README.md
+++ b/examples/ip_address_with_specific_ip/README.md
@@ -5,26 +5,23 @@ allowing GCP to dynamically assign it from the subnet provided).
 
 [^]: (autogen_docs_start)
 
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| addresses | A list of IP addresses to create.  GCP will reserve unreserved addresses if given the value "".  If multiple names are given the default value is sufficient to have multiple addresses automatically picked for each name. | list | - | yes |
-| credentials_path | The path to a Google Cloud Service Account credentials file | string | - | yes |
-| names | A list of IP address resource names to create.  This is the GCP resource name and not the associated hostname of the IP address.  Existing resource names may be found with `gcloud compute addresses list` (e.g. ["gusw1-dev-fooapp-fe-0001-a-001-ip"]) | list | - | yes |
-| project_id | The project ID to deploy to | string | - | yes |
-| region | The region to deploy to | string | - | yes |
-| subnetwork | The subnetwork on which the IP address will be reserved | string | - | yes |
+| addresses | A list of IP addresses to create.  GCP will reserve unreserved addresses if given the value "".  If multiple names are given the default value is sufficient to have multiple addresses automatically picked for each name. | list | n/a | yes |
+| names | A list of IP address resource names to create.  This is the GCP resource name and not the associated hostname of the IP address.  Existing resource names may be found with `gcloud compute addresses list` (e.g. ["gusw1-dev-fooapp-fe-0001-a-001-ip"]) | list | n/a | yes |
+| project\_id | The project ID to deploy to | string | n/a | yes |
+| region | The region to deploy to | string | n/a | yes |
+| subnetwork | The subnetwork on which the IP address will be reserved | string | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
 | addresses | List of address values managed by this module (e.g. ["1.2.3.4"]) |
-| credentials_path | Path to credentials file being used |
 | names | List of address resource names managed by this module (e.g. ["gusw1-dev-fooapp-fe-0001-a-0001-ip"]) |
-| project_id | ID of the project being used |
+| project\_id | ID of the project being used |
 | region | Region being used |
 
 [^]: (autogen_docs_end)

--- a/examples/ip_address_with_specific_ip/main.tf
+++ b/examples/ip_address_with_specific_ip/main.tf
@@ -15,12 +15,12 @@
  */
 
 provider "google" {
-  project = "${var.project_id}"
-  region  = "${var.region}"
+  region = "${var.region}"
 }
 
 module "address" {
   source     = "../../"
+  project_id = "${var.project_id}"
   subnetwork = "${var.subnetwork}"
   names      = "${var.names}"
   addresses  = "${var.addresses}"

--- a/main.tf
+++ b/main.tf
@@ -61,6 +61,7 @@ data "template_file" "ptrs" {
  *****************************************/
 resource "google_compute_address" "ip" {
   count        = "${local.regional_addresses_count}"
+  project      = "${var.project_id}"
   name         = "${element(var.names, count.index)}"
   address      = "${element(var.addresses, count.index)}"
   subnetwork   = "${var.subnetwork}"
@@ -68,8 +69,9 @@ resource "google_compute_address" "ip" {
 }
 
 resource "google_compute_global_address" "global_ip" {
-  count = "${local.global_addresses_count}"
-  name  = "${element(var.names, count.index)}"
+  count   = "${local.global_addresses_count}"
+  project = "${var.project_id}"
+  name    = "${element(var.names, count.index)}"
 }
 
 /******************************************

--- a/test/fixtures/simulated_ci_environment/README.md
+++ b/test/fixtures/simulated_ci_environment/README.md
@@ -33,21 +33,19 @@ For example:
 
 [^]: (autogen_docs_start)
 
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| billing_account | The billing account id associated with the project, e.g. XXXXXX-YYYYYY-ZZZZZZ | string | - | yes |
-| folder_id | The numeric folder id to create resources | string | - | yes |
-| organization_id | The numeric organization id | string | - | yes |
-| project_id | The project_id to deploy the example instance into.  (e.g. "simple-sample-project-1234") | string | - | yes |
-| region | The region to deploy to | string | - | yes |
+| billing\_account | The billing account id associated with the project, e.g. XXXXXX-YYYYYY-ZZZZZZ | string | n/a | yes |
+| folder\_id | The numeric folder id to create resources | string | n/a | yes |
+| organization\_id | The numeric organization id | string | n/a | yes |
+| region | The region to deploy to | string | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| service_account_private_key | The SA KEY JSON content.  Store in GOOGLE_CREDENTIALS. |
+| service\_account\_private\_key | The SA KEY JSON content.  Store in GOOGLE_CREDENTIALS. |
 
 [^]: (autogen_docs_end)

--- a/variables.tf
+++ b/variables.tf
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+variable "project_id" {
+  description = "The project ID to create the address in"
+}
+
 variable "names" {
   description = "A list of IP address resource names to create.  This is the GCP resource name and not the associated hostname of the IP address.  Existing resource names may be found with `gcloud compute addresses list` (e.g. [\"gusw1-dev-fooapp-fe-0001-a-001-ip\"])"
   type        = "list"


### PR DESCRIPTION
Adds a project_id variable as input to follow the convention of the other modules.

Also, updates all the READMEs to use the output from the latest version of `terraform-docs`.