### PR TITLE
Add self_links output

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ Terraform may change this fact, but this is the current limitation.
 | dns\_fqdns | List of DNS fully qualified domain names registered in Cloud DNS.  (e.g. ["gusw1-dev-fooapp-fe-0001-a-001.example.com", "gusw1-dev-fooapp-fe-0001-a-0002.example.com"]) |
 | names | List of address resource names managed by this module (e.g. ["gusw1-dev-fooapp-fe-0001-a-0001-ip"]) |
 | reverse\_dns\_fqdns | List of reverse DNS PTR records registered in Cloud DNS.  (e.g. ["1.2.11.10.in-addr.arpa", "2.2.11.10.in-addr.arpa"]) |
+| self\_links | List of URIs of the created address resources (e.g. ["https://www.googleapis.com/compute/v1/projects/project-abcde/regions/europe-west1/addresses/gusw1-dev-fooapp-fe-0001-a-0001-ip"] |
 
 [^]: (autogen_docs_end)
 

--- a/main.tf
+++ b/main.tf
@@ -33,6 +33,10 @@ locals {
     google_compute_address.ip.*.name,
     google_compute_global_address.global_ip.*.name,
   )
+  self_links = concat(
+    google_compute_address.ip.*.self_link,
+    google_compute_global_address.global_ip.*.self_link,
+  )
   dns_ptr_fqdns = data.template_file.ptrs.*.rendered
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -24,6 +24,11 @@ output "names" {
   value       = local.ip_names
 }
 
+output "self_links" {
+  description = "List of URIs of the created address resources"
+  value       = local.self_links
+}
+
 output "dns_fqdns" {
   description = "List of DNS fully qualified domain names registered in Cloud DNS.  (e.g. [\"gusw1-dev-fooapp-fe-0001-a-001.example.com\", \"gusw1-dev-fooapp-fe-0001-a-0002.example.com\"])"
   value       = local.dns_fqdns


### PR DESCRIPTION
Google cloud NAT module (github.com/terraform-google-modules/terraform-google-cloud-nat?ref=v1.3.0) requires a list of self_links of external IPs, but this module currently doesn't provide that.
This PR adds self_links output to the module