### PR TITLE
Added two new IP address examples: regional external and global external

### DIFF
--- a/examples/global_external_address/README.md
+++ b/examples/global_external_address/README.md
@@ -1,0 +1,26 @@
+# Global external IPv6 address
+
+This example illustrates how to reserve a global external IPv6 address.
+
+The IPv6 address is dynamically assigned by Google Cloud.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| project\_id | The Google Cloud project ID | `any` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| addresses | IP address |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+To provision this example, run the following from within this directory:
+- `terraform init` to get the plugins
+- `terraform plan` to see the infrastructure plan
+- `terraform apply` to apply the infrastructure build
+- `terraform destroy` to destroy the built infrastructure

--- a/examples/global_external_address/main.tf
+++ b/examples/global_external_address/main.tf
@@ -28,12 +28,3 @@ resource "google_compute_global_address" "default" {
   address_type = "EXTERNAL"
   ip_version   = "IPV6"
 }
-
-#module "address" {
-#  source       = "terraform-google-modules/address/google"
-#  version      = "3.0.0"
-#  project_id   = var.project_id # Replace this with your service project ID in quotes
-#  name         = "ipv6-address"
-#  address_type = "EXTERNAL"
-#  ip_version   = "IPV6"
-#}

--- a/examples/global_external_address/main.tf
+++ b/examples/global_external_address/main.tf
@@ -23,10 +23,10 @@ provider "google" {
 }
 
 resource "google_compute_global_address" "default" {
-  project       = var.project_id # Replace this with your service project ID in quotes
-  name          = "ipv6-address"
-  address_type  = "EXTERNAL"
-  ip_version    = "IPV6"
+  project      = var.project_id # Replace this with your service project ID in quotes
+  name         = "ipv6-address"
+  address_type = "EXTERNAL"
+  ip_version   = "IPV6"
 }
 
 #module "address" {

--- a/examples/global_external_address/main.tf
+++ b/examples/global_external_address/main.tf
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+provider "null" {
+  version = "~> 2.1"
+}
+
+provider "google" {
+  version = "~> 3.53.0"
+}
+
+resource "google_compute_global_address" "default" {
+  project       = var.project_id # Replace this with your service project ID in quotes
+  name          = "ipv6-address"
+  address_type  = "EXTERNAL"
+  ip_version    = "IPV6"
+}
+
+#module "address" {
+#  source       = "terraform-google-modules/address/google"
+#  version      = "3.0.0"
+#  project_id   = var.project_id # Replace this with your service project ID in quotes
+#  name         = "ipv6-address"
+#  address_type = "EXTERNAL"
+#  ip_version   = "IPV6"
+#}

--- a/examples/global_external_address/outputs.tf
+++ b/examples/global_external_address/outputs.tf
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "addresses" {
+  description = "IP address"
+  value       = google_compute_global_address.default.address
+}

--- a/examples/global_external_address/variables.tf
+++ b/examples/global_external_address/variables.tf
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project_id" {
+  description = "The Google Cloud project ID"
+}

--- a/examples/global_external_address/versions.tf
+++ b/examples/global_external_address/versions.tf
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_version = ">=0.12.6"
+}

--- a/examples/regional_external_address/README.md
+++ b/examples/regional_external_address/README.md
@@ -1,0 +1,27 @@
+# Regional external IPv4 address
+
+This example illustrates how to reserve a regional external IPv4 address.
+
+The IP address is dynamically assigned by Google Cloud.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| project\_id | The Google Cloud project ID to deploy to | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| addresses | List of address values managed by this module |
+| names | List of address resource names |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+To provision this example, run the following from within this directory:
+- `terraform init` to get the plugins
+- `terraform plan` to see the infrastructure plan
+- `terraform apply` to apply the infrastructure build
+- `terraform destroy` to destroy the built infrastructure

--- a/examples/regional_external_address/main.tf
+++ b/examples/regional_external_address/main.tf
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+provider "null" {
+  version = "~> 2.1"
+}
+
+provider "google" {
+  version = "~> 3.53.0"
+}
+
+module "address" {
+  source  = "terraform-google-modules/address/google"
+  version = "3.0.0"
+  project_id = var.project_id # Replace this with your service project ID in quotes
+  region = "europe-west1"
+  address_type = "EXTERNAL"
+  names = [
+    "regional-external-ip-address-1",
+    "regional-external-ip-address-2",
+    "regional-external-ip-address-3"
+  ]
+}
+

--- a/examples/regional_external_address/main.tf
+++ b/examples/regional_external_address/main.tf
@@ -23,10 +23,10 @@ provider "google" {
 }
 
 module "address" {
-  source  = "terraform-google-modules/address/google"
-  version = "3.0.0"
-  project_id = var.project_id # Replace this with your service project ID in quotes
-  region = "europe-west1"
+  source       = "terraform-google-modules/address/google"
+  version      = "3.0.0"
+  project_id   = var.project_id # Replace this with your service project ID in quotes
+  region       = "europe-west1"
   address_type = "EXTERNAL"
   names = [
     "regional-external-ip-address-1",

--- a/examples/regional_external_address/outputs.tf
+++ b/examples/regional_external_address/outputs.tf
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "names" {
+  description = "List of address resource names"
+  value       = module.address.names
+}
+
+output "addresses" {
+  description = "List of address values managed by this module"
+  value       = module.address.addresses
+}
+
+

--- a/examples/regional_external_address/variables.tf
+++ b/examples/regional_external_address/variables.tf
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project_id" {
+  type        = string
+  description = "The Google Cloud project ID to deploy to"
+}

--- a/examples/regional_external_address/versions.tf
+++ b/examples/regional_external_address/versions.tf
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_version = ">=0.12.6"
+}


### PR DESCRIPTION
Intend to use on Terraform tab in this section:

https://cloud.google.com/compute/docs/ip-addresses/reserve-static-external-ip-address#reserve_new_static