### PR TITLE
Modified internal IP address examples to use hard-coded values

### DIFF
--- a/examples/global_external_address/main.tf
+++ b/examples/global_external_address/main.tf
@@ -23,7 +23,7 @@ provider "google" {
 }
 
 resource "google_compute_global_address" "default" {
-  project      = var.project_id # Replace this with your service project ID in quotes
+  project      = var.project_id # Replace this with your project ID in quotes
   name         = "ipv6-address"
   address_type = "EXTERNAL"
   ip_version   = "IPV6"

--- a/examples/ip_address_only/README.md
+++ b/examples/ip_address_only/README.md
@@ -16,8 +16,6 @@ IP addresses with the addresses dynamically assigned by Google Cloud.
 |------|-------------|
 | addresses | List of address values managed by this module (e.g. ["1.2.3.4"]) |
 | names | List of address resource names managed by this module (e.g. ["gusw1-dev-fooapp-fe-0001-a-0001-ip"]) |
-| project\_id | ID of the project being used |
-| region | Region being used |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/examples/ip_address_only/README.md
+++ b/examples/ip_address_only/README.md
@@ -1,18 +1,14 @@
-# Simple Example
+# Reserving internal IPv4 address with specific IP addresses
 
-This example illustrates how to simply reserve an IP address that is
-dynamically assigned by GCP. Outputs have been provided to list the address
-itself as well as the resource name that corresponds.
+This example illustrates how to reserve internal
+IP addresses with the addresses dynamically assigned by Google Cloud.
 
-[^]: (autogen_docs_start)
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| names | A list of IP address resource names to create.  This is the GCP resource name and not the associated hostname of the IP address.  Existing resource names may be found with `gcloud compute addresses list` (e.g. ["gusw1-dev-fooapp-fe-0001-a-001-ip"]) | `list(string)` | n/a | yes |
-| project\_id | The project ID to deploy to | `string` | n/a | yes |
-| region | The region to deploy to | `string` | n/a | yes |
-| subnetwork | The subnetwork on which the IP address will be reserved | `string` | n/a | yes |
+| project\_id | The Google Cloud project ID to deploy to | `string` | n/a | yes |
 
 ## Outputs
 
@@ -23,7 +19,7 @@ itself as well as the resource name that corresponds.
 | project\_id | ID of the project being used |
 | region | Region being used |
 
-[^]: (autogen_docs_end)
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 To provision this example, run the following from within this directory:
 - `terraform init` to get the plugins

--- a/examples/ip_address_only/main.tf
+++ b/examples/ip_address_only/main.tf
@@ -14,15 +14,20 @@
  * limitations under the License.
  */
 
+provider "null" {
+  version = "~> 2.1"
+}
+
 provider "google" {
-  region = var.region
+  version = "~> 3.53.0"
 }
 
 module "address" {
-  source     = "../../"
-  project_id = var.project_id
-  region     = var.region
-  subnetwork = var.subnetwork
-  names      = var.names
+  source     = "terraform-google-modules/address/google"
+  version    = "3.0.0"
+  project_id = var.project_id # Replace this with your project ID in quotes
+  region     = "asia-east1"
+  subnetwork = "my-subnet"
+  names      = ["internal-address1", "internal-address2"]
 }
 

--- a/examples/ip_address_only/terraform.tfvars.sample
+++ b/examples/ip_address_only/terraform.tfvars.sample
@@ -1,9 +1,0 @@
-# Region and Project setup
-region           = "us-west1"
-project_id       = "my-project-name"
-
-# Subnetwork where the IP Address will be reserved
-subnetwork       = ""
-
-# List of GCP resource names for each IP address desired
-names            = [""]

--- a/examples/ip_address_only/test_outputs.tf
+++ b/examples/ip_address_only/test_outputs.tf
@@ -1,1 +1,0 @@
-../../test/fixtures/all_examples/test_outputs.tfshared

--- a/examples/ip_address_only/variables.tf
+++ b/examples/ip_address_only/variables.tf
@@ -16,21 +16,5 @@
 
 variable "project_id" {
   type        = string
-  description = "The project ID to deploy to"
+  description = "The Google Cloud project ID to deploy to"
 }
-
-variable "region" {
-  type        = string
-  description = "The region to deploy to"
-}
-
-variable "subnetwork" {
-  type        = string
-  description = "The subnetwork on which the IP address will be reserved"
-}
-
-variable "names" {
-  description = "A list of IP address resource names to create.  This is the GCP resource name and not the associated hostname of the IP address.  Existing resource names may be found with `gcloud compute addresses list` (e.g. [\"gusw1-dev-fooapp-fe-0001-a-001-ip\"])"
-  type        = list(string)
-}
-

--- a/examples/ip_address_with_specific_ip/README.md
+++ b/examples/ip_address_with_specific_ip/README.md
@@ -1,18 +1,15 @@
-# Simple Example
+# Reserving internal IPv4 address with specific IP addresses
 
-This example illustrates how to reserve a specific IP address (instead of
-allowing GCP to dynamically assign it from the subnet provided).
+This example illustrates how to reserve specific internal
+IP addresses (instead of allowing Google Cloud to dynamically
+assign them from the subnet provided).
 
-[^]: (autogen_docs_start)
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| addresses | A list of IP addresses to create.  GCP will reserve unreserved addresses if given the value "".  If multiple names are given the default value is sufficient to have multiple addresses automatically picked for each name. | `list(string)` | n/a | yes |
-| names | A list of IP address resource names to create.  This is the GCP resource name and not the associated hostname of the IP address.  Existing resource names may be found with `gcloud compute addresses list` (e.g. ["gusw1-dev-fooapp-fe-0001-a-001-ip"]) | `list(string)` | n/a | yes |
-| project\_id | The project ID to deploy to | `string` | n/a | yes |
-| region | The region to deploy to | `string` | n/a | yes |
-| subnetwork | The subnetwork on which the IP address will be reserved | `string` | n/a | yes |
+| project\_id | The Google Cloud project ID to deploy to | `string` | n/a | yes |
 
 ## Outputs
 
@@ -23,7 +20,7 @@ allowing GCP to dynamically assign it from the subnet provided).
 | project\_id | ID of the project being used |
 | region | Region being used |
 
-[^]: (autogen_docs_end)
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 To provision this example, run the following from within this directory:
 - `terraform init` to get the plugins

--- a/examples/ip_address_with_specific_ip/README.md
+++ b/examples/ip_address_with_specific_ip/README.md
@@ -17,8 +17,6 @@ assign them from the subnet provided).
 |------|-------------|
 | addresses | List of address values managed by this module (e.g. ["1.2.3.4"]) |
 | names | List of address resource names managed by this module (e.g. ["gusw1-dev-fooapp-fe-0001-a-0001-ip"]) |
-| project\_id | ID of the project being used |
-| region | Region being used |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/examples/ip_address_with_specific_ip/main.tf
+++ b/examples/ip_address_with_specific_ip/main.tf
@@ -14,16 +14,21 @@
  * limitations under the License.
  */
 
+provider "null" {
+  version = "~> 2.1"
+}
+
 provider "google" {
-  region = var.region
+  version = "~> 3.53.0"
 }
 
 module "address" {
-  source     = "../../"
-  project_id = var.project_id
-  region     = var.region
-  subnetwork = var.subnetwork
-  names      = var.names
-  addresses  = var.addresses
+  source     = "terraform-google-modules/address/google"
+  version    = "3.0.0"
+  project_id = var.project_id # Replace this with your project ID in quotes
+  region     = "asia-east1"
+  subnetwork = "my-subnet"
+  names      = ["internal-address1", "internal-address2"]
+  addresses  = ["10.0.0.3", "10.0.0.4"]
 }
 

--- a/examples/ip_address_with_specific_ip/test_outputs.tf
+++ b/examples/ip_address_with_specific_ip/test_outputs.tf
@@ -1,1 +1,0 @@
-../../test/fixtures/all_examples/test_outputs.tfshared

--- a/examples/ip_address_with_specific_ip/variables.tf
+++ b/examples/ip_address_with_specific_ip/variables.tf
@@ -16,26 +16,5 @@
 
 variable "project_id" {
   type        = string
-  description = "The project ID to deploy to"
+  description = "The Google Cloud project ID to deploy to"
 }
-
-variable "region" {
-  type        = string
-  description = "The region to deploy to"
-}
-
-variable "subnetwork" {
-  type        = string
-  description = "The subnetwork on which the IP address will be reserved"
-}
-
-variable "names" {
-  description = "A list of IP address resource names to create.  This is the GCP resource name and not the associated hostname of the IP address.  Existing resource names may be found with `gcloud compute addresses list` (e.g. [\"gusw1-dev-fooapp-fe-0001-a-001-ip\"])"
-  type        = list(string)
-}
-
-variable "addresses" {
-  description = "A list of IP addresses to create.  GCP will reserve unreserved addresses if given the value \"\".  If multiple names are given the default value is sufficient to have multiple addresses automatically picked for each name."
-  type        = list(string)
-}
-

--- a/examples/regional_external_address/main.tf
+++ b/examples/regional_external_address/main.tf
@@ -25,7 +25,7 @@ provider "google" {
 module "address" {
   source       = "terraform-google-modules/address/google"
   version      = "3.0.0"
-  project_id   = var.project_id # Replace this with your service project ID in quotes
+  project_id   = var.project_id # Replace this with your project ID in quotes
   region       = "europe-west1"
   address_type = "EXTERNAL"
   names = [


### PR DESCRIPTION
Planning to use in this section:

https://cloud.google.com/compute/docs/ip-addresses/reserve-static-internal-ip-address#reservenewip