### PR TITLE
Removing need for deprecated template terraform provider

### DIFF
--- a/examples/dns_forward_and_reverse/main.tf
+++ b/examples/dns_forward_and_reverse/main.tf
@@ -19,17 +19,17 @@ provider "google" {
 }
 
 module "address" {
-  source           = "../../"
-  project_id       = var.project_id
-  region           = var.region
-  subnetwork       = var.subnetwork
-  enable_cloud_dns = true
+  source             = "../../"
+  project_id         = var.project_id
+  region             = var.region
+  subnetwork         = var.subnetwork
+  enable_cloud_dns   = true
   enable_reverse_dns = true
-  dns_domain       = var.dns_domain
-  dns_managed_zone = var.dns_managed_zone
-  dns_reverse_zone = var.dns_reverse_zone
-  dns_project      = var.dns_project
-  names            = var.names
-  dns_short_names  = var.dns_short_names
+  dns_domain         = var.dns_domain
+  dns_managed_zone   = var.dns_managed_zone
+  dns_reverse_zone   = var.dns_reverse_zone
+  dns_project        = var.dns_project
+  names              = var.names
+  dns_short_names    = var.dns_short_names
 }
 

--- a/examples/dns_forward_and_reverse/main.tf
+++ b/examples/dns_forward_and_reverse/main.tf
@@ -24,6 +24,7 @@ module "address" {
   region           = var.region
   subnetwork       = var.subnetwork
   enable_cloud_dns = true
+  enable_reverse_dns = true
   dns_domain       = var.dns_domain
   dns_managed_zone = var.dns_managed_zone
   dns_reverse_zone = var.dns_reverse_zone


### PR DESCRIPTION
Also fixing DNS test (previously was not creating PTR records).

Previously, it seems like PTR records would only be created for regional IPs (as the `count` was set to the number of regional_ips). Was this intentional? It will now create PTR records for all reserved IP addresses, which as far as I can tell is perfectly valid.

Addresses #37 