### PR TITLE
feat: add labels to the global ip address

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -71,6 +71,7 @@ resource "google_compute_global_address" "global_ip" {
   purpose       = var.global && var.address_type == "INTERNAL" ? "VPC_PEERING" : null
   prefix_length = local.prefix_length
   ip_version    = var.ip_version
+  labels       = var.labels
   description   = try(element(var.descriptions, count.index), null)
 }
 


### PR DESCRIPTION
Hey team
I noticed we cannot add labels to the global ip address even though the provider allows it
Please review :pray: 
Thanks!