### PR TITLE
feat!: use for_each instead of count

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,12 @@ address resource which exists independent of the lifecycle of the resources
 that require the address.
 
 ## Compatibility
-This module is meant for use with Terraform 0.13. If you haven't
-[upgraded](https://www.terraform.io/upgrade-guides/0-13.html) and need a Terraform
-0.12.x-compatible version of this module, the last released version
-intended for Terraform 0.12.x is [v2.1.1](https://registry.terraform.io/modules/terraform-google-modules/-address/google/v2.1.1).
+This module is meant for use with Terraform 1.3+ and tested using Terraform 1.10+.
+If you find incompatibilities using Terraform >=1.3, please open an issue.
+
+If you haven't [upgraded to v6.0](./docs/upgrading_to_v6.0.md) and need the
+previous `count`-based interface, the last released version supporting it is
+[v5.0](https://registry.terraform.io/modules/terraform-google-modules/address/google/5.0.0).
 
 ## Examples without DNS
 
@@ -21,17 +23,17 @@ following example:
 ```hcl
 module "address-fe" {
   source  = "terraform-google-modules/address/google"
-  version = "~> 5.0"
+  version = "~> 6.0"
 
   project_id = "gcp-network"
-  region = "us-west1"
+  region     = "us-west1"
 
   subnetwork = "projects/gcp-network/regions/us-west1/subnetworks/dev-us-west1-dynamic"
 
-  names = [
-    "gusw1-dev-fooapp-fe-0001-a-001-ip",
-    "gusw1-dev-fooapp-fe-0001-a-002-ip",
-    "gusw1-dev-fooapp-fe-0001-a-003-ip"
+  addresses = [
+    { name = "gusw1-dev-fooapp-fe-0001-a-001-ip" },
+    { name = "gusw1-dev-fooapp-fe-0001-a-002-ip" },
+    { name = "gusw1-dev-fooapp-fe-0001-a-003-ip" },
   ]
 }
 ```
@@ -44,47 +46,54 @@ Then perform the following commands on the root folder:
 - `terraform destroy` to destroy the built infrastructure
 
 An `addresses` output has been provided as the list of IP addresses that were
-reserved by GCP. Because the `addresses` input variable was not specified, GCP has
-reserved the next available IP addresses from the subnetwork provided. The number
-of IP addresses reserved is equal to the length of the `names` input
-variable, so size that list accordingly.
+reserved by GCP, in the same order as the `addresses` input. Because the
+`address` attribute was not specified, GCP has reserved the next available IP
+addresses from the subnetwork provided. Each entry in the `addresses` input
+reserves one IP address, keyed in state by its `name`, so adding or removing
+an entry does not affect the other reserved addresses.
 
-If you would prefer to provide the specific IP addresses to be reserved, that can be accomplished with the `addresses` input variable:
+If you would prefer to provide the specific IP addresses to be reserved, that
+can be accomplished with the `address` attribute:
 
 ```hcl
 module "address-fe" {
   source  = "terraform-google-modules/address/google"
-  version = "~> 3.1"
+  version = "~> 6.0"
+
+  project_id = "gcp-network"
+  region     = "us-west1"
 
   subnetwork = "projects/gcp-network/regions/us-west1/subnetworks/dev-us-west1-dynamic"
 
-  names = [
-    "gusw1-dev-fooapp-fe-0001-a-001-ip",
-    "gusw1-dev-fooapp-fe-0001-a-002-ip",
-    "gusw1-dev-fooapp-fe-0001-a-003-ip"
-  ]
-
   addresses = [
-    "10.11.0.10",
-    "10.11.0.11",
-    "10.11.0.12"
+    { name = "gusw1-dev-fooapp-fe-0001-a-001-ip", address = "10.11.0.10" },
+    { name = "gusw1-dev-fooapp-fe-0001-a-002-ip", address = "10.11.0.11" },
+    { name = "gusw1-dev-fooapp-fe-0001-a-003-ip", address = "10.11.0.12" },
   ]
 }
 ```
 
 Note that the IP addresses must not be reserved and must fall within the range of the provided subnetwork.
 
+Most attributes may be set per address or once at the module level to act as
+the default for every address that does not set its own value (e.g.
+`address_type`, `subnetwork`, `labels`, and the `dns_*` settings).
+
 ### External IP address
 
-External IP addresses can be reserved by setting the `global` input var to `true` and omitting the subnetwork:
+External IP addresses can be reserved by setting the `global` attribute to `true` and omitting the subnetwork:
 
 ```hcl
 module "address-fe" {
   source  = "terraform-google-modules/address/google"
-  version = "~> 3.1"
+  version = "~> 6.0"
 
-  names  = ["external-facing-ip"]
-  global = true
+  project_id = "gcp-network"
+  region     = "us-west1"
+
+  addresses = [
+    { name = "external-facing-ip", global = true, address_type = "EXTERNAL" },
+  ]
 }
 ```
 
@@ -92,135 +101,131 @@ module "address-fe" {
 
 Optionally, the IP addresses you reserve can be registered in Google Cloud
 DNS by providing information on the project hosting the Cloud DNS zone, the
-managed zone name, the domain registered with Cloud DNS, and setting the
-`enable_cloud_dns` feature flag to `true`:
+managed zone name, the domain registered with Cloud DNS, setting the
+`enable_cloud_dns` feature flag to `true`, and listing the DNS short names to
+register for each address:
 
 ```hcl
 module "address-fe" {
   source  = "terraform-google-modules/address/google"
-  version = "~> 3.1"
+  version = "~> 6.0"
 
-  subnetwork           = "projects/gcp-network/regions/us-west1/subnetworks/dev-us-west1-dynamic"
-  enable_cloud_dns     = true
-  dns_project          = "gcp-dns"
-  dns_domain           = "example.com"
-  dns_managed_zone     = "nonprod-dns-zone"
+  project_id = "gcp-network"
+  region     = "us-west1"
 
-  names = [
-    "gusw1-dev-fooapp-fe-0001-a-001-ip",
-    "gusw1-dev-fooapp-fe-0001-a-002-ip",
-    "gusw1-dev-fooapp-fe-0001-a-003-ip"
-  ]
+  subnetwork       = "projects/gcp-network/regions/us-west1/subnetworks/dev-us-west1-dynamic"
+  enable_cloud_dns = true
+  dns_project      = "gcp-dns"
+  dns_domain       = "example.com"
+  dns_managed_zone = "nonprod-dns-zone"
 
-  dns_short_names = [
-    "gusw1-dev-fooapp-fe-0001-a-001",
-    "gusw1-dev-fooapp-fe-0001-a-002",
-    "gusw1-dev-fooapp-fe-0001-a-003"
+  addresses = [
+    { name = "gusw1-dev-fooapp-fe-0001-a-001-ip", dns_short_names = ["gusw1-dev-fooapp-fe-0001-a-001"] },
+    { name = "gusw1-dev-fooapp-fe-0001-a-002-ip", dns_short_names = ["gusw1-dev-fooapp-fe-0001-a-002"] },
+    { name = "gusw1-dev-fooapp-fe-0001-a-003-ip", dns_short_names = ["gusw1-dev-fooapp-fe-0001-a-003"] },
   ]
 }
 ```
 
+Multiple DNS names may be registered to the same address by listing several
+`dns_short_names` on a single address.
+
 ### Reverse DNS
 
 The module also supports the ability to register reverse DNS entries within
-their own zone by setting the `enable_gcp_ptr` feature flag to `true` and
+their own zone by setting the `enable_reverse_dns` feature flag to `true` and
 specifying the zone with the `dns_reverse_zone` input variable:
 
 ```hcl
 module "address-fe" {
   source  = "terraform-google-modules/address/google"
-  version = "~> 3.1"
+  version = "~> 6.0"
 
-  subnetwork           = "projects/gcp-network/regions/us-west1/subnetworks/dev-us-west1-dynamic"
-  enable_cloud_dns     = true
-  enable_gcp_ptr       = true
-  dns_project          = "gcp-dns"
-  dns_domain           = "example.com"
-  dns_managed_zone     = "nonprod-dns-zone"
-  dns_reverse_zone     = "nonprod-dns-reverse-zone"
+  project_id = "gcp-network"
+  region     = "us-west1"
 
-  names = [
-    "gusw1-dev-fooapp-fe-0001-a-001-ip",
-    "gusw1-dev-fooapp-fe-0001-a-002-ip",
-    "gusw1-dev-fooapp-fe-0001-a-003-ip"
-  ]
+  subnetwork         = "projects/gcp-network/regions/us-west1/subnetworks/dev-us-west1-dynamic"
+  enable_cloud_dns   = true
+  enable_reverse_dns = true
+  dns_project        = "gcp-dns"
+  dns_domain         = "example.com"
+  dns_managed_zone   = "nonprod-dns-zone"
+  dns_reverse_zone   = "nonprod-dns-reverse-zone"
 
-  dns_short_names = [
-    "gusw1-dev-fooapp-fe-0001-a-001",
-    "gusw1-dev-fooapp-fe-0001-a-002",
-    "gusw1-dev-fooapp-fe-0001-a-003"
+  addresses = [
+    { name = "gusw1-dev-fooapp-fe-0001-a-001-ip", dns_short_names = ["gusw1-dev-fooapp-fe-0001-a-001"] },
+    { name = "gusw1-dev-fooapp-fe-0001-a-002-ip", dns_short_names = ["gusw1-dev-fooapp-fe-0001-a-002"] },
+    { name = "gusw1-dev-fooapp-fe-0001-a-003-ip", dns_short_names = ["gusw1-dev-fooapp-fe-0001-a-003"] },
   ]
 }
 ```
 
-As with the non-DNS examples above, the `addresses` input variable can be
-provided with a list of specific IP addresses to be reserved if desired.
+The PTR record of an address points at the first entry of its
+`dns_short_names`.
 
-## Input variables that cannot contain computed values
+As with the non-DNS examples above, the `address` attribute can be provided
+for each address to reserve specific IPs if desired.
 
-Because of the way the module is structured, and due to the fact that
-Terraform doesn't yet support computed count values, there are certain input
-variables whose values cannot be computed values. The list of those input
-variables is as follows:
+## Input attributes that cannot contain computed values
+
+Resources are keyed in state by address `name` (and by `name`/`dns_short_names`
+pairs for DNS records) using `for_each`. Terraform requires `for_each` keys to
+be known at plan time, so the following attributes of the `addresses` input
+cannot be computed values:
 
 ```
-var.dns_domain
-var.dns_short_names
-var.enable_cloud_dns
-var.enable_reverse_dns
-var.global
-var.names
+name
+dns_short_names
+enable_cloud_dns
+enable_reverse_dns
+global
 ```
 
-You must currently use literal values for these input variables. If you
-don't you run the risk of failing validation (at the least) or surfacing the
-dreaded `value of 'count' cannot be computed` error. Future versions of
-Terraform may change this fact, but this is the current limitation.
+You must use literal values (or values known at plan time) for these
+attributes. Other attributes, including `address` and `dns_domain`, may be
+computed.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| address\_type | The type of address to reserve, either "INTERNAL" or "EXTERNAL". If unspecified, defaults to "INTERNAL". | `string` | `"INTERNAL"` | no |
-| addresses | A list of IP addresses to create.  GCP will reserve unreserved addresses if given the value "".  If multiple names are given the default value is sufficient to have multiple addresses automatically picked for each name. | `list(string)` | <pre>[<br>  ""<br>]</pre> | no |
-| descriptions | A list of descriptions to add to each address. | `list(string)` | `[]` | no |
-| dns\_domain | The domain to append to DNS short names when registering in Cloud DNS. | `string` | `""` | no |
-| dns\_managed\_zone | The name of the managed zone to create records within.  This managed zone must exist in the host project. | `string` | `""` | no |
-| dns\_project | The project where DNS A records will be configured. | `string` | `""` | no |
-| dns\_record\_type | The type of records to create in the managed zone.  (e.g. "A") | `string` | `"A"` | no |
-| dns\_reverse\_zone | The name of the managed zone to create PTR records within.  This managed zone must exist in the host project. | `string` | `""` | no |
-| dns\_short\_names | A list of DNS short names to register within Cloud DNS.  Names corresponding to addresses must align by their list index position in the two input variables, `names` and `dns_short_names`.  If an empty list, no domain names are registered.  Multiple names may be registered to the same address by passing a single element list to names and multiple elements to dns\_short\_names.  (e.g. ["gusw1-dev-fooapp-fe-0001-a-001"]) | `list(string)` | `[]` | no |
-| dns\_ttl | The DNS TTL in seconds for records created in Cloud DNS.  The default value should be used unless the application demands special handling. | `number` | `300` | no |
-| enable\_cloud\_dns | If a value is set, register records in Cloud DNS. | `bool` | `false` | no |
-| enable\_reverse\_dns | If a value is set, register reverse DNS PTR records in Cloud DNS in the managed zone specified by dns\_reverse\_zone | `bool` | `false` | no |
-| global | The scope in which the address should live. If set to true, the IP address will be globally scoped. Defaults to false, i.e. regionally scoped. When set to true, do not provide a subnetwork. | `bool` | `false` | no |
-| ip\_version | The IP Version that will be used by this address. | `string` | `"IPV4"` | no |
-| labels | Labels to apply to this address. | `map(string)` | `{}` | no |
-| names | A list of IP address resource names to create. This is the GCP resource name and not the associated hostname of the IP address. Existing resource names may be found with `gcloud compute addresses list` (e.g. ["gusw1-dev-fooapp-fe-0001-a-001-ip"]) | `list(string)` | n/a | yes |
-| network\_tier | The networking tier used for configuring this address. | `string` | `"PREMIUM"` | no |
-| prefix\_length | The prefix length of the IP range. | `number` | `16` | no |
-| project\_id | The project ID to create the address in | `string` | n/a | yes |
-| purpose | The purpose of the resource(GCE\_ENDPOINT, SHARED\_LOADBALANCER\_VIP, VPC\_PEERING). | `string` | `"GCE_ENDPOINT"` | no |
-| region | The region to create the address in | `string` | n/a | yes |
-| subnetwork | The subnet containing the address.  For EXTERNAL addresses use the empty string, "".  (e.g. "projects/<project-name>/regions/<region-name>/subnetworks/<subnetwork-name>") | `string` | `""` | no |
+| address\_type | The default type of address to reserve, either "INTERNAL" or "EXTERNAL". If unspecified, defaults to "INTERNAL". | `string` | `"INTERNAL"` | no |
+| addresses | A list of IP addresses to reserve, keyed by `name`. Each attribute left unset (`null`) falls back to the matching module-level variable when one exists. Set `address` to reserve a specific IP, leave it unset to let GCP pick one. Set `global` to true for a global address. `dns_short_names` registers forward DNS records for the address when `enable_cloud_dns` is set, and the first short name is used for the PTR record when `enable_reverse_dns` is set. | <pre>list(object({<br>    name               = string<br>    address            = optional(string)<br>    description        = optional(string)<br>    region             = optional(string)<br>    global             = optional(bool, false)<br>    address_type       = optional(string)<br>    subnetwork         = optional(string)<br>    ip_version         = optional(string)<br>    labels             = optional(map(string))<br>    purpose            = optional(string)<br>    network_tier       = optional(string)<br>    prefix_length      = optional(number)<br>    enable_cloud_dns   = optional(bool)<br>    enable_reverse_dns = optional(bool)<br>    dns_short_names    = optional(list(string), [])<br>    dns_domain         = optional(string)<br>    dns_managed_zone   = optional(string)<br>    dns_reverse_zone   = optional(string)<br>    dns_record_type    = optional(string)<br>    dns_ttl            = optional(number)<br>    dns_project        = optional(string)<br>  }))</pre> | n/a | yes |
+| dns\_domain | The default domain to append to DNS short names when registering in Cloud DNS. | `string` | `""` | no |
+| dns\_managed\_zone | The default name of the managed zone to create records within.  This managed zone must exist in the host project. | `string` | `""` | no |
+| dns\_project | The default project where DNS records will be configured. Falls back to `project_id` if unset. | `string` | `""` | no |
+| dns\_record\_type | The default type of records to create in the managed zone.  (e.g. "A") | `string` | `"A"` | no |
+| dns\_reverse\_zone | The default name of the managed zone to create PTR records within.  This managed zone must exist in the host project. | `string` | `""` | no |
+| dns\_ttl | The default DNS TTL in seconds for records created in Cloud DNS.  The default value should be used unless the application demands special handling. | `number` | `300` | no |
+| enable\_cloud\_dns | If set, register records in Cloud DNS for addresses that do not set their own `enable_cloud_dns` attribute. | `bool` | `false` | no |
+| enable\_reverse\_dns | If set, register reverse DNS PTR records in Cloud DNS for addresses that do not set their own `enable_reverse_dns` attribute. | `bool` | `false` | no |
+| ip\_version | The default IP Version that will be used by the addresses. | `string` | `"IPV4"` | no |
+| labels | The default labels to apply to the addresses. | `map(string)` | `{}` | no |
+| network\_tier | The default networking tier used for configuring the addresses. | `string` | `"PREMIUM"` | no |
+| prefix\_length | The default prefix length of the IP ranges. | `number` | `16` | no |
+| project\_id | The project ID to create the addresses in | `string` | n/a | yes |
+| purpose | The default purpose of the resource (GCE\_ENDPOINT, SHARED\_LOADBALANCER\_VIP, VPC\_PEERING, PRIVATE\_SERVICE\_CONNECT). | `string` | `"GCE_ENDPOINT"` | no |
+| region | The default region to create regional addresses in. May be overridden per address with the `region` attribute. | `string` | n/a | yes |
+| subnetwork | The default subnet containing the addresses.  For EXTERNAL addresses use the empty string, "".  (e.g. "projects/<project-name>/regions/<region-name>/subnetworks/<subnetwork-name>") | `string` | `""` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| addresses | List of address values managed by this module (e.g. ["1.2.3.4"]) |
+| addresses | List of address values managed by this module (e.g. ["1.2.3.4"]), in the same order as the `addresses` input. |
+| addresses\_map | Map of address values managed by this module, keyed by address name. |
 | dns\_fqdns | List of DNS fully qualified domain names registered in Cloud DNS.  (e.g. ["gusw1-dev-fooapp-fe-0001-a-001.example.com", "gusw1-dev-fooapp-fe-0001-a-0002.example.com"]) |
-| names | List of address resource names managed by this module (e.g. ["gusw1-dev-fooapp-fe-0001-a-0001-ip"]) |
+| names | List of address resource names managed by this module (e.g. ["gusw1-dev-fooapp-fe-0001-a-0001-ip"]), in the same order as the `addresses` input. |
 | reverse\_dns\_fqdns | List of reverse DNS PTR records registered in Cloud DNS.  (e.g. ["1.2.11.10.in-addr.arpa", "2.2.11.10.in-addr.arpa"]) |
-| self\_links | List of URIs of the created address resources |
+| self\_links | List of URIs of the created address resources, in the same order as the `addresses` input. |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 
 ## Requirements
 ### Terraform plugins
-- [Terraform](https://www.terraform.io/downloads.html) >= 0.13.0
+- [Terraform](https://www.terraform.io/downloads.html) >= 1.3
 - [terraform-provider-google](https://github.com/terraform-providers/terraform-provider-google) plugin >= 5.2.0
 
 ### Configure a Service Account

--- a/docs/upgrading_to_v6.0.md
+++ b/docs/upgrading_to_v6.0.md
@@ -1,0 +1,79 @@
+# Upgrading to v6.0
+
+The v6.0 release is a backwards incompatible release. The module now uses
+`for_each` instead of `count` to manage its resources, so addresses are keyed
+in state by their name instead of their position in a list. Adding or removing
+an address no longer affects the other addresses managed by the module.
+
+## Terraform version
+
+Terraform 1.3 or later is required (the `addresses` variable uses `optional()`
+object attributes).
+
+## Input changes
+
+The `names`, `global`, `dns_short_names`, and `descriptions` list variables
+were removed, and the `addresses` variable changed from a list of IP strings to
+a list of objects — one object per address to reserve:
+
+```diff
+ module "address" {
+   source  = "terraform-google-modules/address/google"
+-  version = "~> 5.0"
++  version = "~> 6.0"
+
+   project_id       = var.project_id
+   region           = var.region
+   subnetwork       = var.subnetwork
+   enable_cloud_dns = true
+   dns_domain       = "example.com"
+   dns_managed_zone = "nonprod-dns-zone"
+
+-  names           = ["my-ip-1", "my-ip-2"]
+-  addresses       = ["10.0.0.10", "10.0.0.11"]
+-  dns_short_names = ["short-1", "short-2"]
++  addresses = [
++    { name = "my-ip-1", address = "10.0.0.10", dns_short_names = ["short-1"] },
++    { name = "my-ip-2", address = "10.0.0.11", dns_short_names = ["short-2"] },
++  ]
+ }
+```
+
+Every module-level variable that used to apply to all addresses
+(`address_type`, `subnetwork`, `labels`, `purpose`, `network_tier`,
+`prefix_length`, `ip_version`, `region`, and the `dns_*` and `enable_*`
+variables) still exists and acts as the default, and can now also be
+overridden per address with the attribute of the same name.
+
+Each address object supports the following attributes (only `name` is
+required): `address`, `description`, `region`, `global`, `address_type`,
+`subnetwork`, `ip_version`, `labels`, `purpose`, `network_tier`,
+`prefix_length`, `enable_cloud_dns`, `enable_reverse_dns`, `dns_short_names`,
+`dns_domain`, `dns_managed_zone`, `dns_reverse_zone`, `dns_record_type`,
+`dns_ttl`, and `dns_project`.
+
+## Output changes
+
+Outputs keep the same names and list shapes, ordered by the `addresses` input.
+A new `addresses_map` output exposes the reserved IPs keyed by address name.
+
+## State migration
+
+Because resources are now keyed by name instead of index, existing resources
+must be moved in state to avoid destroying and recreating the reserved
+addresses. For each address, add a `moved` block (or run the equivalent
+`terraform state mv` commands):
+
+```hcl
+moved {
+  from = module.address.google_compute_address.ip[0]
+  to   = module.address.google_compute_address.ip["my-ip-1"]
+}
+```
+
+The same applies to `google_compute_global_address.global_ip` (keyed by name),
+`google_dns_record_set.ip` (now keyed by `"<address name>/<dns short name>"`),
+and `google_dns_record_set.ptr` (keyed by address name).
+
+Run `terraform plan` after the migration and confirm that no resources are
+planned for destruction.

--- a/examples/dns_forward_and_reverse/main.tf
+++ b/examples/dns_forward_and_reverse/main.tf
@@ -31,7 +31,11 @@ module "address" {
   dns_managed_zone   = var.dns_managed_zone
   dns_reverse_zone   = var.dns_reverse_zone
   dns_project        = var.dns_project
-  names              = var.names
-  dns_short_names    = var.dns_short_names
+  addresses = [
+    for index, name in var.names : {
+      name            = name
+      dns_short_names = [var.dns_short_names[index]]
+    }
+  ]
 }
 

--- a/examples/dns_forward_example/main.tf
+++ b/examples/dns_forward_example/main.tf
@@ -29,7 +29,11 @@ module "address" {
   dns_domain       = var.dns_domain
   dns_managed_zone = var.dns_managed_zone
   dns_project      = var.dns_project
-  names            = var.names
-  dns_short_names  = var.dns_short_names
+  addresses = [
+    for index, name in var.names : {
+      name            = name
+      dns_short_names = [var.dns_short_names[index]]
+    }
+  ]
 }
 

--- a/examples/dns_forward_example_multi_names/main.tf
+++ b/examples/dns_forward_example_multi_names/main.tf
@@ -29,13 +29,15 @@ module "address" {
   dns_domain       = local.domain
   dns_managed_zone = google_dns_managed_zone.forward.name
   dns_project      = var.project_id
-  names = [
-    "dynamically-reserved-ip-040",
-  ]
-  dns_short_names = [
-    "testip-041",
-    "testip-042",
-    "testip-043",
+  addresses = [
+    {
+      name = "dynamically-reserved-ip-040"
+      dns_short_names = [
+        "testip-041",
+        "testip-042",
+        "testip-043",
+      ]
+    }
   ]
   address_type = "EXTERNAL"
 }

--- a/examples/internal_with_dynamic_ip/main.tf
+++ b/examples/internal_with_dynamic_ip/main.tf
@@ -21,6 +21,9 @@ module "address" {
   project_id = var.project_id # Replace this with your project ID in quotes
   region     = "asia-east1"
   subnetwork = "my-subnet"
-  names      = ["internal-address1", "internal-address2"]
+  addresses = [
+    { name = "internal-address1" },
+    { name = "internal-address2" },
+  ]
 }
 # [END compute_internal_ip_create]

--- a/examples/internal_with_specific_ip/main.tf
+++ b/examples/internal_with_specific_ip/main.tf
@@ -21,7 +21,9 @@ module "address" {
   project_id = var.project_id # Replace this with your project ID in quotes
   region     = "asia-east1"
   subnetwork = "my-subnet"
-  names      = ["internal-address1", "internal-address2"]
-  addresses  = ["10.0.0.3", "10.0.0.4"]
+  addresses = [
+    { name = "internal-address1", address = "10.0.0.3" },
+    { name = "internal-address2", address = "10.0.0.4" },
+  ]
 }
 # [END compute_internal_ip_create]

--- a/examples/ip_address_only/main.tf
+++ b/examples/ip_address_only/main.tf
@@ -25,6 +25,6 @@ module "address" {
   project_id = var.project_id
   region     = var.region
   subnetwork = var.subnetwork
-  names      = var.names
+  addresses  = [for name in var.names : { name = name }]
 }
 

--- a/examples/ip_address_with_specific_ip/main.tf
+++ b/examples/ip_address_with_specific_ip/main.tf
@@ -25,7 +25,11 @@ module "address" {
   project_id = var.project_id
   region     = var.region
   subnetwork = var.subnetwork
-  names      = var.names
-  addresses  = var.addresses
+  addresses = [
+    for index, name in var.names : {
+      name    = name
+      address = var.addresses[index]
+    }
+  ]
 }
 

--- a/examples/regional_external_address/main.tf
+++ b/examples/regional_external_address/main.tf
@@ -21,10 +21,10 @@ module "address" {
   project_id   = var.project_id # Replace this with your service project ID in quotes
   region       = "europe-west1"
   address_type = "EXTERNAL"
-  names = [
-    "regional-external-ip-address-1",
-    "regional-external-ip-address-2",
-    "regional-external-ip-address-3"
+  addresses = [
+    { name = "regional-external-ip-address-1" },
+    { name = "regional-external-ip-address-2" },
+    { name = "regional-external-ip-address-3" },
   ]
 }
 # [END compute_external_ip_create]

--- a/main.tf
+++ b/main.tf
@@ -18,82 +18,118 @@
   Locals configuration and validation
  *****************************************/
 locals {
-  dns_fqdns                = formatlist("%s.%s", var.dns_short_names, var.dns_domain)
-  regional_addresses_count = var.global ? 0 : length(var.names)
-  global_addresses_count   = var.global ? length(var.names) : 0
-  dns_forward_record_count = var.enable_cloud_dns ? length(local.dns_fqdns) : 0
-  dns_reverse_record_count = var.enable_reverse_dns ? length(local.dns_fqdns) : 0
-  ip_addresses = concat(
-    google_compute_address.ip[*].address,
-    google_compute_global_address.global_ip[*].address,
-  )
-  ip_names = concat(
-    google_compute_address.ip[*].name,
-    google_compute_global_address.global_ip[*].name,
-  )
-  self_links = concat(
-    google_compute_address.ip[*].self_link,
-    google_compute_global_address.global_ip[*].self_link,
-  )
-  prefix_length = var.address_type == "EXTERNAL" || (var.address_type == "INTERNAL" && var.purpose == "PRIVATE_SERVICE_CONNECT") ? null : var.prefix_length
+  # Addresses keyed by name, with unset per-address attributes falling back
+  # to the module-level defaults.
+  addresses = {
+    for addr in var.addresses : addr.name => merge(addr, {
+      region             = addr.region != null ? addr.region : var.region
+      address_type       = addr.address_type != null ? addr.address_type : var.address_type
+      subnetwork         = addr.subnetwork != null ? addr.subnetwork : var.subnetwork
+      ip_version         = addr.ip_version != null ? addr.ip_version : var.ip_version
+      labels             = addr.labels != null ? addr.labels : var.labels
+      purpose            = addr.purpose != null ? addr.purpose : var.purpose
+      network_tier       = addr.network_tier != null ? addr.network_tier : var.network_tier
+      prefix_length      = addr.prefix_length != null ? addr.prefix_length : var.prefix_length
+      enable_cloud_dns   = addr.enable_cloud_dns != null ? addr.enable_cloud_dns : var.enable_cloud_dns
+      enable_reverse_dns = addr.enable_reverse_dns != null ? addr.enable_reverse_dns : var.enable_reverse_dns
+      dns_domain         = addr.dns_domain != null ? addr.dns_domain : var.dns_domain
+      dns_managed_zone   = addr.dns_managed_zone != null ? addr.dns_managed_zone : var.dns_managed_zone
+      dns_reverse_zone   = addr.dns_reverse_zone != null ? addr.dns_reverse_zone : var.dns_reverse_zone
+      dns_record_type    = addr.dns_record_type != null ? addr.dns_record_type : var.dns_record_type
+      dns_ttl            = addr.dns_ttl != null ? addr.dns_ttl : var.dns_ttl
+      dns_project        = coalesce(addr.dns_project, var.dns_project, var.project_id)
+    })
+  }
+
+  regional_addresses = { for name, addr in local.addresses : name => addr if !addr.global }
+  global_addresses   = { for name, addr in local.addresses : name => addr if addr.global }
+
+  ip_addresses = {
+    for name, addr in local.addresses :
+    name => addr.global ? google_compute_global_address.global_ip[name].address : google_compute_address.ip[name].address
+  }
+  self_links = {
+    for name, addr in local.addresses :
+    name => addr.global ? google_compute_global_address.global_ip[name].self_link : google_compute_address.ip[name].self_link
+  }
+
+  dns_fqdns = {
+    for name, addr in local.addresses :
+    name => [for short_name in addr.dns_short_names : format("%s.%s", short_name, addr.dns_domain)]
+  }
+
+  # One forward record per (address, dns short name) pair. Keyed by
+  # "<address name>/<short name>" so keys are known at plan time even when
+  # the DNS domain is computed.
+  dns_forward_records = merge([
+    for name, addr in local.addresses : {
+      for index, short_name in addr.dns_short_names :
+      "${name}/${short_name}" => merge(addr, {
+        address_name = name
+        fqdn         = local.dns_fqdns[name][index]
+      })
+    } if addr.enable_cloud_dns
+  ]...)
 
   /******************************************
   Format reverse DNS entries - see https://github.com/hashicorp/terraform/issues/9404
   *****************************************/
-  split_ips     = [for ip in local.ip_addresses : split(".", ip)]
-  dns_ptr_fqdns = var.enable_reverse_dns ? [for split_ip in local.split_ips : "${split_ip[3]}.${split_ip[2]}.${split_ip[1]}.${split_ip[0]}.in-addr.arpa"] : []
+  dns_ptr_fqdns = {
+    for name, addr in local.addresses :
+    name => format("%s.in-addr.arpa", join(".", reverse(split(".", local.ip_addresses[name]))))
+    if addr.enable_reverse_dns
+  }
 }
 
 /******************************************
   IP address reservation
  *****************************************/
 resource "google_compute_address" "ip" {
-  count        = local.regional_addresses_count
+  for_each     = local.regional_addresses
   project      = var.project_id
-  region       = var.region
-  name         = element(var.names, count.index)
-  address      = element(var.addresses, count.index)
-  subnetwork   = var.subnetwork
-  address_type = var.address_type
-  purpose      = var.address_type == "INTERNAL" ? var.purpose : null
-  network_tier = var.address_type == "INTERNAL" ? null : var.network_tier
-  labels       = var.labels
-  description  = try(element(var.descriptions, count.index), null)
+  region       = each.value.region
+  name         = each.key
+  address      = each.value.address
+  subnetwork   = each.value.address_type == "INTERNAL" ? each.value.subnetwork : null
+  address_type = each.value.address_type
+  purpose      = each.value.address_type == "INTERNAL" ? each.value.purpose : null
+  network_tier = each.value.address_type == "INTERNAL" ? null : each.value.network_tier
+  labels       = each.value.labels
+  description  = each.value.description
 }
 
 resource "google_compute_global_address" "global_ip" {
-  count         = local.global_addresses_count
+  for_each      = local.global_addresses
   project       = var.project_id
-  name          = var.names[count.index]
-  address_type  = var.address_type
-  address       = element(var.addresses, count.index)
-  network       = var.address_type == "EXTERNAL" ? null : var.subnetwork
-  purpose       = var.global && var.address_type == "INTERNAL" ? "VPC_PEERING" : null
-  prefix_length = local.prefix_length
-  ip_version    = var.ip_version
-  description   = try(element(var.descriptions, count.index), null)
+  name          = each.key
+  address_type  = each.value.address_type
+  address       = each.value.address
+  network       = each.value.address_type == "EXTERNAL" ? null : each.value.subnetwork
+  purpose       = each.value.address_type == "INTERNAL" ? (each.value.purpose == "PRIVATE_SERVICE_CONNECT" ? "PRIVATE_SERVICE_CONNECT" : "VPC_PEERING") : null
+  prefix_length = each.value.address_type == "EXTERNAL" || (each.value.address_type == "INTERNAL" && each.value.purpose == "PRIVATE_SERVICE_CONNECT") ? null : each.value.prefix_length
+  ip_version    = each.value.ip_version
+  description   = each.value.description
 }
 
 /******************************************
   Forward and reverse DNS entries - note the trailing dot in name
  *****************************************/
 resource "google_dns_record_set" "ip" {
-  count        = local.dns_forward_record_count
-  name         = "${local.dns_fqdns[count.index]}."
-  managed_zone = var.dns_managed_zone
-  type         = var.dns_record_type
-  ttl          = var.dns_ttl
-  rrdatas      = length(local.ip_addresses) == 1 ? [local.ip_addresses[0]] : [local.ip_addresses[count.index]]
-  project      = var.dns_project
+  for_each     = local.dns_forward_records
+  name         = "${each.value.fqdn}."
+  managed_zone = each.value.dns_managed_zone
+  type         = each.value.dns_record_type
+  ttl          = each.value.dns_ttl
+  rrdatas      = [local.ip_addresses[each.value.address_name]]
+  project      = each.value.dns_project
 }
 
 resource "google_dns_record_set" "ptr" {
-  count        = local.dns_reverse_record_count
-  name         = "${local.dns_ptr_fqdns[count.index]}."
-  managed_zone = var.dns_reverse_zone
+  for_each     = local.dns_ptr_fqdns
+  name         = "${each.value}."
+  managed_zone = local.addresses[each.key].dns_reverse_zone
   type         = "PTR"
-  ttl          = var.dns_ttl
-  rrdatas      = ["${local.dns_fqdns[count.index]}."]
-  project      = var.dns_project
+  ttl          = local.addresses[each.key].dns_ttl
+  rrdatas      = ["${local.dns_fqdns[each.key][0]}."]
+  project      = local.addresses[each.key].dns_project
 }
-

--- a/metadata.display.yaml
+++ b/metadata.display.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -75,8 +75,8 @@ spec:
         names:
           name: names
           title: Names
-          regexValidation: "^[a-z]([-a-z0-9]*[a-z0-9])?$"
-          validation: "Each name must be 1-63 chars, start with lowercase, and be RFC1035 compliant."
+          regexValidation: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+          validation: Each name must be 1-63 chars, start with lowercase, and be RFC1035 compliant.
         network_tier:
           name: network_tier
           title: Network Tier

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ spec:
     version: 5.0.0
     actuationTool:
       flavor: Terraform
-      version: ">= 0.13"
+      version: ">= 1.3"
     description: {}
   content:
     examples:
@@ -51,36 +51,42 @@ spec:
   interfaces:
     variables:
       - name: project_id
-        description: The project ID to create the address in
+        description: The project ID to create the addresses in
         varType: string
         required: true
       - name: region
-        description: The region to create the address in
+        description: The default region to create regional addresses in. May be overridden per address with the `region` attribute.
         varType: string
-        required: true
-      - name: names
-        description: A list of IP address resource names to create.  This is the GCP resource name and not the associated hostname of the IP address.  Existing resource names may be found with `gcloud compute addresses list` (e.g. ["gusw1-dev-fooapp-fe-0001-a-001-ip"])
-        varType: list(string)
         required: true
       - name: addresses
-        description: A list of IP addresses to create.  GCP will reserve unreserved addresses if given the value "".  If multiple names are given the default value is sufficient to have multiple addresses automatically picked for each name.
-        varType: list(string)
-        defaultValue:
-          - ""
-      - name: global
-        description: The scope in which the address should live. If set to true, the IP address will be globally scoped. Defaults to false, i.e. regionally scoped. When set to true, do not provide a subnetwork.
-        varType: bool
-        defaultValue: false
-      - name: dns_short_names
-        description: A list of DNS short names to register within Cloud DNS.  Names corresponding to addresses must align by their list index position in the two input variables, `names` and `dns_short_names`.  If an empty list, no domain names are registered.  Multiple names may be registered to the same address by passing a single element list to names and multiple elements to dns_short_names.  (e.g. ["gusw1-dev-fooapp-fe-0001-a-001"])
-        varType: list(string)
-        defaultValue: []
-      - name: dns_domain
-        description: The domain to append to DNS short names when registering in Cloud DNS.
-        varType: string
-        defaultValue: ""
+        description: A list of IP addresses to reserve, keyed by `name`. Each attribute left unset (`null`) falls back to the matching module-level variable when one exists. Set `address` to reserve a specific IP, leave it unset to let GCP pick one. Set `global` to true for a global address. `dns_short_names` registers forward DNS records for the address when `enable_cloud_dns` is set, and the first short name is used for the PTR record when `enable_reverse_dns` is set.
+        varType: |-
+          list(object({
+              name               = string
+              address            = optional(string)
+              description        = optional(string)
+              region             = optional(string)
+              global             = optional(bool, false)
+              address_type       = optional(string)
+              subnetwork         = optional(string)
+              ip_version         = optional(string)
+              labels             = optional(map(string))
+              purpose            = optional(string)
+              network_tier       = optional(string)
+              prefix_length      = optional(number)
+              enable_cloud_dns   = optional(bool)
+              enable_reverse_dns = optional(bool)
+              dns_short_names    = optional(list(string), [])
+              dns_domain         = optional(string)
+              dns_managed_zone   = optional(string)
+              dns_reverse_zone   = optional(string)
+              dns_record_type    = optional(string)
+              dns_ttl            = optional(number)
+              dns_project        = optional(string)
+            }))
+        required: true
       - name: dns_project
-        description: The project where DNS A records will be configured.
+        description: The default project where DNS records will be configured. Falls back to `project_id` if unset.
         varType: string
         defaultValue: ""
         connections:
@@ -89,12 +95,16 @@ spec:
               version: ~> 5.2
             spec:
               outputExpr: project_id
+      - name: dns_domain
+        description: The default domain to append to DNS short names when registering in Cloud DNS.
+        varType: string
+        defaultValue: ""
       - name: dns_ttl
-        description: The DNS TTL in seconds for records created in Cloud DNS.  The default value should be used unless the application demands special handling.
+        description: The default DNS TTL in seconds for records created in Cloud DNS.  The default value should be used unless the application demands special handling.
         varType: number
         defaultValue: 300
       - name: dns_managed_zone
-        description: The name of the managed zone to create records within.  This managed zone must exist in the host project.
+        description: The default name of the managed zone to create records within.  This managed zone must exist in the host project.
         varType: string
         defaultValue: ""
         connections:
@@ -104,15 +114,23 @@ spec:
             spec:
               outputExpr: name
       - name: dns_reverse_zone
-        description: The name of the managed zone to create PTR records within.  This managed zone must exist in the host project.
+        description: The default name of the managed zone to create PTR records within.  This managed zone must exist in the host project.
         varType: string
         defaultValue: ""
       - name: dns_record_type
-        description: The type of records to create in the managed zone.  (e.g. "A")
+        description: The default type of records to create in the managed zone.  (e.g. "A")
         varType: string
         defaultValue: A
+      - name: enable_cloud_dns
+        description: If set, register records in Cloud DNS for addresses that do not set their own `enable_cloud_dns` attribute.
+        varType: bool
+        defaultValue: false
+      - name: enable_reverse_dns
+        description: If set, register reverse DNS PTR records in Cloud DNS for addresses that do not set their own `enable_reverse_dns` attribute.
+        varType: bool
+        defaultValue: false
       - name: subnetwork
-        description: The subnet containing the address.  For EXTERNAL addresses use the empty string, "".  (e.g. "projects/<project-name>/regions/<region-name>/subnetworks/<subnetwork-name>")
+        description: The default subnet containing the addresses.  For EXTERNAL addresses use the empty string, "".  (e.g. "projects/<project-name>/regions/<region-name>/subnetworks/<subnetwork-name>")
         varType: string
         defaultValue: ""
         connections:
@@ -122,54 +140,44 @@ spec:
             spec:
               outputExpr: subnets[0].self_link
       - name: address_type
-        description: The type of address to reserve, either "INTERNAL" or "EXTERNAL". If unspecified, defaults to "INTERNAL".
+        description: The default type of address to reserve, either "INTERNAL" or "EXTERNAL". If unspecified, defaults to "INTERNAL".
         varType: string
         defaultValue: INTERNAL
-      - name: enable_cloud_dns
-        description: If a value is set, register records in Cloud DNS.
-        varType: bool
-        defaultValue: false
-      - name: enable_reverse_dns
-        description: If a value is set, register reverse DNS PTR records in Cloud DNS in the managed zone specified by dns_reverse_zone
-        varType: bool
-        defaultValue: false
       - name: purpose
-        description: The purpose of the resource(GCE_ENDPOINT, SHARED_LOADBALANCER_VIP, VPC_PEERING).
+        description: The default purpose of the resource (GCE_ENDPOINT, SHARED_LOADBALANCER_VIP, VPC_PEERING, PRIVATE_SERVICE_CONNECT).
         varType: string
         defaultValue: GCE_ENDPOINT
       - name: network_tier
-        description: The networking tier used for configuring this address.
+        description: The default networking tier used for configuring the addresses.
         varType: string
         defaultValue: PREMIUM
       - name: prefix_length
-        description: The prefix length of the IP range.
+        description: The default prefix length of the IP ranges.
         varType: number
         defaultValue: 16
       - name: ip_version
-        description: The IP Version that will be used by this address.
+        description: The default IP Version that will be used by the addresses.
         varType: string
         defaultValue: IPV4
       - name: labels
-        description: Labels to apply to this address.
+        description: The default labels to apply to the addresses.
         varType: map(string)
         defaultValue: {}
-      - name: descriptions
-        description: A list of descriptions to add to each address.
-        varType: list(string)
-        defaultValue: []
     outputs:
       - name: addresses
-        description: List of address values managed by this module (e.g. ["1.2.3.4"])
+        description: List of address values managed by this module (e.g. ["1.2.3.4"]), in the same order as the `addresses` input.
         type:
           - list
           - string
+      - name: addresses_map
+        description: Map of address values managed by this module, keyed by address name.
       - name: dns_fqdns
         description: List of DNS fully qualified domain names registered in Cloud DNS.  (e.g. ["gusw1-dev-fooapp-fe-0001-a-001.example.com", "gusw1-dev-fooapp-fe-0001-a-0002.example.com"])
         type:
           - list
           - string
       - name: names
-        description: List of address resource names managed by this module (e.g. ["gusw1-dev-fooapp-fe-0001-a-0001-ip"])
+        description: List of address resource names managed by this module (e.g. ["gusw1-dev-fooapp-fe-0001-a-0001-ip"]), in the same order as the `addresses` input.
         type:
           - list
           - string
@@ -179,7 +187,7 @@ spec:
           - list
           - string
       - name: self_links
-        description: List of URIs of the created address resources
+        description: List of URIs of the created address resources, in the same order as the `addresses` input.
         type:
           - list
           - string

--- a/outputs.tf
+++ b/outputs.tf
@@ -15,27 +15,31 @@
  */
 
 output "addresses" {
-  description = "List of address values managed by this module (e.g. [\"1.2.3.4\"])"
+  description = "List of address values managed by this module (e.g. [\"1.2.3.4\"]), in the same order as the `addresses` input."
+  value       = [for addr in var.addresses : local.ip_addresses[addr.name]]
+}
+
+output "addresses_map" {
+  description = "Map of address values managed by this module, keyed by address name."
   value       = local.ip_addresses
 }
 
 output "names" {
-  description = "List of address resource names managed by this module (e.g. [\"gusw1-dev-fooapp-fe-0001-a-0001-ip\"])"
-  value       = local.ip_names
+  description = "List of address resource names managed by this module (e.g. [\"gusw1-dev-fooapp-fe-0001-a-0001-ip\"]), in the same order as the `addresses` input."
+  value       = [for addr in var.addresses : addr.name]
 }
 
 output "self_links" {
-  description = "List of URIs of the created address resources"
-  value       = local.self_links
+  description = "List of URIs of the created address resources, in the same order as the `addresses` input."
+  value       = [for addr in var.addresses : local.self_links[addr.name]]
 }
 
 output "dns_fqdns" {
   description = "List of DNS fully qualified domain names registered in Cloud DNS.  (e.g. [\"gusw1-dev-fooapp-fe-0001-a-001.example.com\", \"gusw1-dev-fooapp-fe-0001-a-0002.example.com\"])"
-  value       = local.dns_fqdns
+  value       = flatten([for addr in var.addresses : local.dns_fqdns[addr.name]])
 }
 
 output "reverse_dns_fqdns" {
   description = "List of reverse DNS PTR records registered in Cloud DNS.  (e.g. [\"1.2.11.10.in-addr.arpa\", \"2.2.11.10.in-addr.arpa\"])"
-  value       = local.dns_ptr_fqdns
+  value       = [for addr in var.addresses : local.dns_ptr_fqdns[addr.name] if contains(keys(local.dns_ptr_fqdns), addr.name)]
 }
-

--- a/variables.tf
+++ b/variables.tf
@@ -16,136 +16,139 @@
 
 variable "project_id" {
   type        = string
-  description = "The project ID to create the address in"
+  description = "The project ID to create the addresses in"
 }
 
 variable "region" {
   type        = string
-  description = "The region to create the address in"
-}
-
-variable "names" {
-  description = "A list of IP address resource names to create. This is the GCP resource name and not the associated hostname of the IP address. Existing resource names may be found with `gcloud compute addresses list` (e.g. [\"gusw1-dev-fooapp-fe-0001-a-001-ip\"])"
-  type        = list(string)
-
-  validation {
-    condition = alltrue([
-      for n in var.names : can(regex("^[a-z]([-a-z0-9]*[a-z0-9])?$", n)) && length(n) <= 63
-    ])
-    error_message = "Each name must be 1-63 chars, start with lowercase, and be RFC1035 compliant."
-  }
+  description = "The default region to create regional addresses in. May be overridden per address with the `region` attribute."
 }
 
 variable "addresses" {
-  description = "A list of IP addresses to create.  GCP will reserve unreserved addresses if given the value \"\".  If multiple names are given the default value is sufficient to have multiple addresses automatically picked for each name."
-  type        = list(string)
-  default     = [""]
+  description = "A list of IP addresses to reserve, keyed by `name`. Each attribute left unset (`null`) falls back to the matching module-level variable when one exists. Set `address` to reserve a specific IP, leave it unset to let GCP pick one. Set `global` to true for a global address. `dns_short_names` registers forward DNS records for the address when `enable_cloud_dns` is set, and the first short name is used for the PTR record when `enable_reverse_dns` is set."
+  type = list(object({
+    name               = string
+    address            = optional(string)
+    description        = optional(string)
+    region             = optional(string)
+    global             = optional(bool, false)
+    address_type       = optional(string)
+    subnetwork         = optional(string)
+    ip_version         = optional(string)
+    labels             = optional(map(string))
+    purpose            = optional(string)
+    network_tier       = optional(string)
+    prefix_length      = optional(number)
+    enable_cloud_dns   = optional(bool)
+    enable_reverse_dns = optional(bool)
+    dns_short_names    = optional(list(string), [])
+    dns_domain         = optional(string)
+    dns_managed_zone   = optional(string)
+    dns_reverse_zone   = optional(string)
+    dns_record_type    = optional(string)
+    dns_ttl            = optional(number)
+    dns_project        = optional(string)
+  }))
+
+  validation {
+    condition = alltrue([
+      for addr in var.addresses : can(regex("^[a-z]([-a-z0-9]*[a-z0-9])?$", addr.name)) && length(addr.name) <= 63
+    ])
+    error_message = "Each name must be 1-63 chars, start with lowercase, and be RFC1035 compliant."
+  }
+
+  validation {
+    condition     = length(distinct([for addr in var.addresses : addr.name])) == length(var.addresses)
+    error_message = "Address names must be unique."
+  }
 }
 
-variable "global" {
-  description = "The scope in which the address should live. If set to true, the IP address will be globally scoped. Defaults to false, i.e. regionally scoped. When set to true, do not provide a subnetwork."
-  type        = bool
-  default     = false
-}
-
-variable "dns_short_names" {
-  description = "A list of DNS short names to register within Cloud DNS.  Names corresponding to addresses must align by their list index position in the two input variables, `names` and `dns_short_names`.  If an empty list, no domain names are registered.  Multiple names may be registered to the same address by passing a single element list to names and multiple elements to dns_short_names.  (e.g. [\"gusw1-dev-fooapp-fe-0001-a-001\"])"
-  type        = list(string)
-  default     = []
-}
-
-variable "dns_domain" {
-  description = "The domain to append to DNS short names when registering in Cloud DNS."
+variable "dns_project" {
+  description = "The default project where DNS records will be configured. Falls back to `project_id` if unset."
   type        = string
   default     = ""
 }
 
-variable "dns_project" {
-  description = "The project where DNS A records will be configured."
+variable "dns_domain" {
+  description = "The default domain to append to DNS short names when registering in Cloud DNS."
   type        = string
   default     = ""
 }
 
 variable "dns_ttl" {
   type        = number
-  description = "The DNS TTL in seconds for records created in Cloud DNS.  The default value should be used unless the application demands special handling."
+  description = "The default DNS TTL in seconds for records created in Cloud DNS.  The default value should be used unless the application demands special handling."
   default     = 300
 }
 
 variable "dns_managed_zone" {
   type        = string
-  description = "The name of the managed zone to create records within.  This managed zone must exist in the host project."
+  description = "The default name of the managed zone to create records within.  This managed zone must exist in the host project."
   default     = ""
 }
 
 variable "dns_reverse_zone" {
   type        = string
-  description = "The name of the managed zone to create PTR records within.  This managed zone must exist in the host project."
+  description = "The default name of the managed zone to create PTR records within.  This managed zone must exist in the host project."
   default     = ""
 }
 
 variable "dns_record_type" {
   type        = string
-  description = "The type of records to create in the managed zone.  (e.g. \"A\")"
+  description = "The default type of records to create in the managed zone.  (e.g. \"A\")"
   default     = "A"
 }
 
-variable "subnetwork" {
-  type        = string
-  description = "The subnet containing the address.  For EXTERNAL addresses use the empty string, \"\".  (e.g. \"projects/<project-name>/regions/<region-name>/subnetworks/<subnetwork-name>\")"
-  default     = ""
-}
-
-variable "address_type" {
-  type        = string
-  description = "The type of address to reserve, either \"INTERNAL\" or \"EXTERNAL\". If unspecified, defaults to \"INTERNAL\"."
-  default     = "INTERNAL"
-}
-
 variable "enable_cloud_dns" {
-  description = "If a value is set, register records in Cloud DNS."
+  description = "If set, register records in Cloud DNS for addresses that do not set their own `enable_cloud_dns` attribute."
   type        = bool
   default     = false
 }
 
 variable "enable_reverse_dns" {
-  description = "If a value is set, register reverse DNS PTR records in Cloud DNS in the managed zone specified by dns_reverse_zone"
+  description = "If set, register reverse DNS PTR records in Cloud DNS for addresses that do not set their own `enable_reverse_dns` attribute."
   type        = bool
   default     = false
 }
 
+variable "subnetwork" {
+  type        = string
+  description = "The default subnet containing the addresses.  For EXTERNAL addresses use the empty string, \"\".  (e.g. \"projects/<project-name>/regions/<region-name>/subnetworks/<subnetwork-name>\")"
+  default     = ""
+}
+
+variable "address_type" {
+  type        = string
+  description = "The default type of address to reserve, either \"INTERNAL\" or \"EXTERNAL\". If unspecified, defaults to \"INTERNAL\"."
+  default     = "INTERNAL"
+}
+
 variable "purpose" {
   type        = string
-  description = "The purpose of the resource(GCE_ENDPOINT, SHARED_LOADBALANCER_VIP, VPC_PEERING)."
+  description = "The default purpose of the resource (GCE_ENDPOINT, SHARED_LOADBALANCER_VIP, VPC_PEERING, PRIVATE_SERVICE_CONNECT)."
   default     = "GCE_ENDPOINT"
 }
 
 variable "network_tier" {
   type        = string
-  description = "The networking tier used for configuring this address."
+  description = "The default networking tier used for configuring the addresses."
   default     = "PREMIUM"
 }
 
 variable "prefix_length" {
   type        = number
-  description = "The prefix length of the IP range."
+  description = "The default prefix length of the IP ranges."
   default     = 16
 }
 
 variable "ip_version" {
   type        = string
-  description = "The IP Version that will be used by this address."
+  description = "The default IP Version that will be used by the addresses."
   default     = "IPV4"
 }
 
 variable "labels" {
   type        = map(string)
-  description = "Labels to apply to this address."
+  description = "The default labels to apply to the addresses."
   default     = {}
-}
-
-variable "descriptions" {
-  description = "A list of descriptions to add to each address."
-  type        = list(string)
-  default     = []
 }


### PR DESCRIPTION
Fixes #18
Supersedes #118 (rebased on main / v5.0.0, lint findings fixed)

This converts the module from `count` to `for_each`: addresses are now keyed by name in state, so removing one address from the middle of the list no longer touches the others.

The `addresses` variable becomes a list of objects (one per address) and replaces `names`, `global`, `dns_short_names` and `descriptions`. Module-level variables (`address_type`, `subnetwork`, `labels`, the `dns_*` ones...) still act as defaults and can be overridden per address. Registering multiple DNS short names on a single address still works (see the multi_names example).

Outputs keep the same names and list shapes, ordered by the input, so the integration tests didn't need changes. There is a new `addresses_map` output keyed by name.

DNS records are keyed by `<address name>/<short name>` rather than by FQDN, so plans keep working when the domain is computed (the multi_names example uses a random suffix).

Since this is breaking, I added `docs/upgrading_to_v6.0.md` with the input changes and the state moves needed to avoid recreating reserved addresses. Examples, README and metadata are updated, `make docker_test_lint` passes locally.
